### PR TITLE
feat: 카카오페이 결제 서비스 구현

### DIFF
--- a/src/main/java/luckyseven/dart/api/application/payment/PaymentService.java
+++ b/src/main/java/luckyseven/dart/api/application/payment/PaymentService.java
@@ -61,7 +61,7 @@ public class PaymentService {
 		final Member member = memberRepository.findById(id)
 			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_USER_NOT_FOUND));
 		final Gallery gallery = galleryRepository.findById(Long.parseLong(paymentApproveDto.item_code()))
-			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_POST_NOT_FOUND));
+			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_GALLERY_NOT_FOUND));
 		final LocalDateTime approveAt = paymentApproveDto.approved_at();
 		final Payment payment = Payment.create(member, gallery, approveAt, order);
 
@@ -73,7 +73,7 @@ public class PaymentService {
 	private MultiValueMap<String, String> readyToBody(PaymentCreateDto dto) {
 		final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
 		final Gallery gallery = galleryRepository.findById(dto.galleryId())
-			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_POST_NOT_FOUND));
+			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_GALLERY_NOT_FOUND));
 
 		params.add("cid", CID);
 		params.add("partner_order_id", PARTNER_ORDER);

--- a/src/main/java/luckyseven/dart/api/domain/payment/entity/Order.java
+++ b/src/main/java/luckyseven/dart/api/domain/payment/entity/Order.java
@@ -1,0 +1,26 @@
+package luckyseven.dart.api.domain.payment.entity;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Order {
+	TICKET("ticket"),
+	PAID_GALLERY("paidGallery");
+
+	private final String value;
+
+	private static final Map<String, Order> valuesMap = Collections.unmodifiableMap(Stream.of(values())
+		.collect(Collectors.toMap(Order::getValue, Function.identity())));
+
+	public static Order fromValue(String value) {
+		return valuesMap.get(value);
+	}
+}

--- a/src/main/java/luckyseven/dart/api/domain/payment/entity/Payment.java
+++ b/src/main/java/luckyseven/dart/api/domain/payment/entity/Payment.java
@@ -1,6 +1,6 @@
 package luckyseven.dart.api.domain.payment.entity;
 
-import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -15,34 +15,58 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import luckyseven.dart.api.domain.gallery.entity.Gallery;
 import luckyseven.dart.api.domain.member.entity.Member;
 
 @Entity
 @Getter
 @Table(name = "tbl_payment_info")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class PaymentInfo {
+public class Payment {
 	@Id
 	@Column(name = "id")
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
 	@Column(name = "amount")
-	private BigDecimal amount;
+	private int amount;
 
-	@Column(name = "imp_uid")
-	private String impUid;
+	@Column(name = "approved_at")
+	private LocalDateTime approvedAt;
+
+	@Column(name = "`order`")
+	private Order order;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id")
 	private Member member;
 
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "gallery_id")
+	private Gallery gallery;
+
 	@Builder
-	private PaymentInfo(
-		BigDecimal amount,
-		String impUid
+	private Payment(
+		int amount,
+		LocalDateTime approvedAt,
+		Member member,
+		Gallery gallery,
+		Order order
 	) {
 		this.amount = amount;
-		this.impUid = impUid;
+		this.approvedAt = approvedAt;
+		this.member = member;
+		this.gallery = gallery;
+		this.order = order;
+	}
+
+	public static Payment create(Member member, Gallery gallery, LocalDateTime approvedAt, String order) {
+		return Payment.builder()
+			.member(member)
+			.gallery(gallery)
+			.approvedAt(approvedAt)
+			.order(Order.fromValue(order))
+			.amount(gallery.getFee())
+			.build();
 	}
 }

--- a/src/main/java/luckyseven/dart/api/domain/payment/repo/PaymentInfoRepository.java
+++ b/src/main/java/luckyseven/dart/api/domain/payment/repo/PaymentInfoRepository.java
@@ -1,8 +1,0 @@
-package luckyseven.dart.api.domain.payment.repo;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import luckyseven.dart.api.domain.payment.entity.PaymentInfo;
-
-public interface PaymentInfoRepository extends JpaRepository<PaymentInfo, Long> {
-}

--- a/src/main/java/luckyseven/dart/api/domain/payment/repo/PaymentRepository.java
+++ b/src/main/java/luckyseven/dart/api/domain/payment/repo/PaymentRepository.java
@@ -1,0 +1,8 @@
+package luckyseven.dart.api.domain.payment.repo;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import luckyseven.dart.api.domain.payment.entity.Payment;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+}

--- a/src/main/java/luckyseven/dart/dto/payment/request/PaymentCreateDto.java
+++ b/src/main/java/luckyseven/dart/dto/payment/request/PaymentCreateDto.java
@@ -1,7 +1,13 @@
 package luckyseven.dart.dto.payment.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 public record PaymentCreateDto(
+
+	@NotNull
 	Long galleryId,
+	@NotBlank(message = "주문 정보는 필수로 입력해 주세요.")
 	String order
 ) {
 }

--- a/src/main/java/luckyseven/dart/dto/payment/request/PaymentCreateDto.java
+++ b/src/main/java/luckyseven/dart/dto/payment/request/PaymentCreateDto.java
@@ -1,0 +1,7 @@
+package luckyseven.dart.dto.payment.request;
+
+public record PaymentCreateDto(
+	Long galleryId,
+	String order
+) {
+}

--- a/src/main/java/luckyseven/dart/dto/payment/response/AmountDto.java
+++ b/src/main/java/luckyseven/dart/dto/payment/response/AmountDto.java
@@ -1,6 +1,0 @@
-package luckyseven.dart.dto.payment.response;
-
-public record AmountDto(
-	int total
-) {
-}

--- a/src/main/java/luckyseven/dart/dto/payment/response/AmountDto.java
+++ b/src/main/java/luckyseven/dart/dto/payment/response/AmountDto.java
@@ -1,0 +1,6 @@
+package luckyseven.dart.dto.payment.response;
+
+public record AmountDto(
+	int total
+) {
+}

--- a/src/main/java/luckyseven/dart/dto/payment/response/PaymentApproveDto.java
+++ b/src/main/java/luckyseven/dart/dto/payment/response/PaymentApproveDto.java
@@ -1,0 +1,7 @@
+package luckyseven.dart.dto.payment.response;
+
+public record PaymentApproveDto(
+	String item_code,
+	AmountDto amount
+) {
+}

--- a/src/main/java/luckyseven/dart/dto/payment/response/PaymentApproveDto.java
+++ b/src/main/java/luckyseven/dart/dto/payment/response/PaymentApproveDto.java
@@ -1,7 +1,9 @@
 package luckyseven.dart.dto.payment.response;
 
+import java.time.LocalDateTime;
+
 public record PaymentApproveDto(
 	String item_code,
-	AmountDto amount
+	LocalDateTime approved_at
 ) {
 }

--- a/src/main/java/luckyseven/dart/dto/payment/response/PaymentReadyDto.java
+++ b/src/main/java/luckyseven/dart/dto/payment/response/PaymentReadyDto.java
@@ -1,0 +1,10 @@
+package luckyseven.dart.dto.payment.response;
+
+import java.util.Date;
+
+public record PaymentReadyDto(
+	String tid,
+	String next_redirect_pc_url,
+	Date created_at
+) {
+}

--- a/src/main/java/luckyseven/dart/dto/payment/response/PaymentReadyDto.java
+++ b/src/main/java/luckyseven/dart/dto/payment/response/PaymentReadyDto.java
@@ -1,10 +1,7 @@
 package luckyseven.dart.dto.payment.response;
 
-import java.util.Date;
-
 public record PaymentReadyDto(
 	String tid,
-	String next_redirect_pc_url,
-	Date created_at
+	String next_redirect_pc_url
 ) {
 }

--- a/src/main/java/luckyseven/dart/global/common/PaymentConstant.java
+++ b/src/main/java/luckyseven/dart/global/common/PaymentConstant.java
@@ -1,0 +1,18 @@
+package luckyseven.dart.global.common;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PaymentConstant {
+	public static final String READY_URL = "https://kapi.kakao.com/v1/payment/ready";
+	public static final String APPROVE_URL = "https://kapi.kakao.com/v1/payment/approve";
+	public static final String SUCCESS_URL = "http://localhost:8080/api/pay/success";
+	public static final String CANCEL_URL = "http://localhost:8080/api/pay/cancel";
+	public static final String FAIL_URL = "http://localhost:8080/api/pay/fail";
+	public static final String PARTNER_USER = "USER";
+	public static final String PARTNER_ORDER = "DART";
+	public static final String TAX = "0";
+	public static final String CID = "TC0ONETIME";
+	public static final String QUANTITY = "1";
+}

--- a/src/main/java/luckyseven/dart/global/config/PaymentProperties.java
+++ b/src/main/java/luckyseven/dart/global/config/PaymentProperties.java
@@ -1,0 +1,13 @@
+package luckyseven.dart.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+
+@Component
+@Getter
+public class PaymentProperties {
+	@Value("${KAKAO_ADMIN_KEY}")
+	private String adminKey;
+}

--- a/src/main/java/luckyseven/dart/global/error/model/ErrorCode.java
+++ b/src/main/java/luckyseven/dart/global/error/model/ErrorCode.java
@@ -32,7 +32,7 @@ public enum ErrorCode {
 	FAIL_COMMENT_DELETION_FORBIDDEN("[❎ ERROR] 댓글 삭제 권한이 없습니다."),
 
 	// 404 Not Found
-	FAIL_POST_NOT_FOUND("[❎ ERROR] 요청하신 게시글을 찾을 수 없습니다."),
+	FAIL_GALLERY_NOT_FOUND("[❎ ERROR] 요청하신 전시관을 찾을 수 없습니다."),
 	FAIL_USER_NOT_FOUND("[❎ ERROR] 요청하신 회원을 찾을 수 없습니다."),
 	FAIL_COMMENT_NOT_FOUND("[❎ ERROR] 요청하신 댓글을 찾을 수 없습니다."),
 	FAIL_TOKEN_NOT_FOUND("[❎ ERROR] 요청하신 토큰을 찾을 수 없습니다."),
@@ -44,7 +44,6 @@ public enum ErrorCode {
 
 	// 500 Server Error
 	FAIL_INTERNAL_SERVER_ERROR("[❎ ERROR] 서버 내부 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
-
 
 	private String message;
 }

--- a/src/main/java/luckyseven/dart/presentation/PaymentController.java
+++ b/src/main/java/luckyseven/dart/presentation/PaymentController.java
@@ -1,0 +1,48 @@
+package luckyseven.dart.presentation;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import luckyseven.dart.api.application.payment.PaymentService;
+import luckyseven.dart.dto.payment.request.PaymentCreateDto;
+import luckyseven.dart.dto.payment.response.PaymentApproveDto;
+import luckyseven.dart.dto.payment.response.PaymentReadyDto;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/payment")
+public class PaymentController {
+	private final PaymentService paymentService;
+
+	@PostMapping
+	public PaymentReadyDto ready(@RequestBody @Valid PaymentCreateDto dto) {
+		return paymentService.ready(dto);
+	}
+
+	@GetMapping("/success/{id}/{order}")
+	public PaymentApproveDto approve(
+		@RequestParam("pg_token") String token,
+		@PathVariable("id") Long id,
+		@PathVariable("order") String order
+	) {
+		return paymentService.approve(token, id, order);
+	}
+
+	@GetMapping("/cancel")
+	public ResponseEntity<String> cancel() {
+		return ResponseEntity.internalServerError().body("결제 취소");
+	}
+
+	@GetMapping("/fail")
+	public ResponseEntity<String> fail() {
+		return ResponseEntity.internalServerError().body("결제 실패");
+	}
+}


### PR DESCRIPTION
## 📋 CheckList
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. feat: 유저 조회 기능 구현)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

* close #25 

## 👩‍💻 공유 포인트 및 논의 사항
* 유료 전시관 생성 시 & 유료 전시관 입장 시 결제 api를 구현했습니다.
* 카카오 측에서 제공해주는 데이터에서 필요한 데이터만 받아서 사용했는데, 더 필요한 게 있다면 추후 수정하겠습니다.
* 사이드 프로젝트로 성공시켰고, 현재 저희 서비스에 겔러리 생성 & 로그인이 구현되어 있지 않아서 추후에 해당 로직을 추가하겠습니다.
* 실패시, 취소시 에러 문구에 대해서는 로직을 추가할 때 더 상세하게 수정하겠습니다
