### PR TITLE
feat: 전시 생성, 삭제 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,6 +194,7 @@ gradle-app.setting
 
 # Yml
 src/main/resources/application-dev.yml
+src/main/resources/application-secret.yml
 
 # Env
 .env

--- a/build.gradle
+++ b/build.gradle
@@ -1,67 +1,70 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.2.5'
-	id 'io.spring.dependency-management' version '1.1.4'
+    id 'java'
+    id 'org.springframework.boot' version '3.2.5'
+    id 'io.spring.dependency-management' version '1.1.4'
 }
 
 group = 'luckyseven'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+    sourceCompatibility = '17'
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	// Swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 
-	// Web
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+    // Web
+    implementation 'org.springframework.boot:spring-boot-starter-web'
 
-	// JPA
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    // JPA
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
-	// Security
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+    // Security
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 
-	// JWT
-	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
-	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
-	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
-	// Bean validation
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
+    // Bean validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
-	// Lombok
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 
-	// H2
-	runtimeOnly 'com.h2database:h2'
+    // H2
+    runtimeOnly 'com.h2database:h2'
 
-	//MySql
-	runtimeOnly 'com.mysql:mysql-connector-j'
+    //MySql
+    runtimeOnly 'com.mysql:mysql-connector-j'
 
-	// ENV
-	implementation 'io.github.cdimascio:java-dotenv:5.2.2'
+    // ENV
+    implementation 'io.github.cdimascio:java-dotenv:5.2.2'
 
-	// Test
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    // Test
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    //S3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/luckyseven/dart/DartApplication.java
+++ b/src/main/java/luckyseven/dart/DartApplication.java
@@ -2,10 +2,12 @@ package luckyseven.dart;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 import io.github.cdimascio.dotenv.Dotenv;
 import luckyseven.dart.global.config.DotenvEnvironmentLoader;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class DartApplication {
 

--- a/src/main/java/luckyseven/dart/api/application/gallery/GalleryService.java
+++ b/src/main/java/luckyseven/dart/api/application/gallery/GalleryService.java
@@ -1,0 +1,131 @@
+package luckyseven.dart.api.application.gallery;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.RequiredArgsConstructor;
+import luckyseven.dart.api.domain.gallery.entity.Cost;
+import luckyseven.dart.api.domain.gallery.entity.Gallery;
+import luckyseven.dart.api.domain.gallery.entity.Hashtag;
+import luckyseven.dart.api.domain.gallery.entity.Image;
+import luckyseven.dart.api.domain.gallery.repo.GalleryRepository;
+import luckyseven.dart.api.domain.gallery.repo.HashtagRepository;
+import luckyseven.dart.api.domain.gallery.repo.ImageRepository;
+import luckyseven.dart.api.dto.gallery.request.CreateGalleryDto;
+import luckyseven.dart.api.dto.gallery.request.DeleteGalleryDto;
+import luckyseven.dart.api.dto.gallery.request.ImageInfoDto;
+import luckyseven.dart.global.common.util.S3Service;
+import luckyseven.dart.global.error.exception.BadRequestException;
+import luckyseven.dart.global.error.exception.NotFoundException;
+import luckyseven.dart.global.error.model.ErrorCode;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class GalleryService {
+
+	private final GalleryRepository galleryRepository;
+	private final HashtagRepository hashtagRepository;
+	private final ImageRepository imageRepository;
+	private final S3Service s3Service;
+
+	public void createGallery(CreateGalleryDto createGalleryDto, MultipartFile thumbnail,
+		List<MultipartFile> imageFiles) throws IOException {
+		Cost cost = determineCost(createGalleryDto);
+		validateEndDateForPay(cost, createGalleryDto);
+		String thumbnailUrl = s3Service.uploadFile(thumbnail);
+		Gallery gallery = Gallery.create(createGalleryDto, thumbnailUrl, cost);
+		galleryRepository.save(gallery);
+		saveHashtags(createGalleryDto.hashTags(), gallery);
+		saveImages(createGalleryDto.images(), imageFiles, gallery);
+	}
+
+	public void deleteGallery(DeleteGalleryDto deleteGalleryDto) {
+		Gallery gallery = findGalleryById(deleteGalleryDto.galleryId());
+		deleteImagesByGallery(gallery);
+		deleteThumbnail(gallery);
+		deleteHashtagsByGallery(gallery);
+		deleteGalleryEntity(gallery);
+	}
+
+	private void saveHashtags(List<String> hashTags, Gallery gallery) {
+		if (hashTags != null) {
+			validateHashtags(hashTags);
+			List<Hashtag> hashtags = hashTags.stream()
+				.map(tag -> Hashtag.builder().tag(tag).gallery(gallery).build())
+				.collect(Collectors.toList());
+			hashtagRepository.saveAll(hashtags);
+		}
+	}
+
+	private void saveImages(List<ImageInfoDto> imageInfoDtos, List<MultipartFile> imageFiles, Gallery gallery) throws
+		IOException {
+		if (imageInfoDtos != null && !imageInfoDtos.isEmpty()) {
+			for (int i = 0; i < imageInfoDtos.size(); i++) {
+				ImageInfoDto imageInfoDto = imageInfoDtos.get(i);
+				MultipartFile imageFile = imageFiles.get(i);
+				String imageUrl = s3Service.uploadFile(imageFile);
+				Image image = Image.builder()
+					.imageUri(imageUrl)
+					.imageTitle(imageInfoDto.imageTitle())
+					.description(imageInfoDto.description())
+					.gallery(gallery)
+					.build();
+				imageRepository.save(image);
+			}
+		}
+	}
+
+	private Cost determineCost(CreateGalleryDto createGalleryDto) {
+		return createGalleryDto.fee() == 0 ? Cost.FREE : Cost.PAY;
+	}
+
+	private void validateEndDateForPay(Cost cost, CreateGalleryDto createGalleryDto) {
+		if (cost == Cost.PAY && createGalleryDto.endDate() == null) {
+			throw new BadRequestException(ErrorCode.FAIL_INVALID_END_DATE_FOR_PAY);
+		}
+	}
+
+	private void validateHashtags(List<String> hashTags) {
+		if (hashTags.size() > 5) {
+			throw new BadRequestException(ErrorCode.FAIL_HASHTAG_SIZE_EXCEEDED);
+		}
+		Pattern pattern = Pattern.compile("^[^\\s]{1,10}$");
+		boolean invalidTagFound = hashTags.parallelStream().anyMatch(tag -> !pattern.matcher(tag).matches());
+		if (invalidTagFound) {
+			throw new BadRequestException(ErrorCode.FAIL_TAG_CONTAINS_SPACE_OR_INVALID_LENGTH);
+		}
+	}
+
+	private Gallery findGalleryById(Long galleryId) {
+		return galleryRepository.findById(galleryId)
+			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_GALLERY_NOT_FOUND));
+	}
+
+	private void deleteImagesByGallery(Gallery gallery) {
+		List<Image> images = imageRepository.findByGallery(gallery);
+		for (Image image : images) {
+			s3Service.deleteFile(image.getImageUri());
+			imageRepository.delete(image);
+		}
+	}
+
+	private void deleteThumbnail(Gallery gallery) {
+		s3Service.deleteFile(gallery.getThumbnail());
+	}
+
+	private void deleteHashtagsByGallery(Gallery gallery) {
+		List<Hashtag> hashtags = hashtagRepository.findByGallery(gallery);
+		hashtagRepository.deleteAll(hashtags);
+	}
+
+	private void deleteGalleryEntity(Gallery gallery) {
+		galleryRepository.delete(gallery);
+	}
+}

--- a/src/main/java/luckyseven/dart/api/application/gallery/GalleryService.java
+++ b/src/main/java/luckyseven/dart/api/application/gallery/GalleryService.java
@@ -103,14 +103,14 @@ public class GalleryService {
 	}
 
 	private Cost determineCost(CreateGalleryDto createGalleryDto) {
-		if (createGalleryDto.fee() == ZERO) {
+		if (createGalleryDto.fee() == PAYMENT_REQUIRED) {
 			return Cost.FREE;
 		}
 		return Cost.PAY;
 	}
 
 	private void validateImageCount(CreateGalleryDto createGalleryDto) {
-		if (createGalleryDto.images().size() > TWENTY) {
+		if (createGalleryDto.images().size() > MAX_IMAGE_SIZE) {
 			throw new BadRequestException(ErrorCode.FAIL_EXHIBITION_ITEM_LIMIT_EXCEEDED);
 		}
 	}
@@ -128,7 +128,7 @@ public class GalleryService {
 	}
 
 	private void validateHashtagsSize(List<String> hashTags) {
-		if (hashTags.size() > FIVE) {
+		if (hashTags.size() > MAX_HASHTAG_SIZE) {
 			throw new BadRequestException(ErrorCode.FAIL_HASHTAG_SIZE_EXCEEDED);
 		}
 	}

--- a/src/main/java/luckyseven/dart/api/application/gallery/GalleryService.java
+++ b/src/main/java/luckyseven/dart/api/application/gallery/GalleryService.java
@@ -86,7 +86,7 @@ public class GalleryService {
 	private void processImage(ImageInfoDto imageInfoDto, MultipartFile imageFile, Gallery gallery) {
 		try {
 			String imageUrl = s3Service.uploadFile(imageFile);
-			Image image = createImageEntity(imageInfoDto, imageUrl, gallery);
+			final Image image = createImageEntity(imageInfoDto, imageUrl, gallery);
 			imageRepository.save(image);
 		} catch (IOException e) {
 			throw new BadRequestException(ErrorCode.FAIL_INVALID_REQUEST);

--- a/src/main/java/luckyseven/dart/api/application/gallery/GalleryService.java
+++ b/src/main/java/luckyseven/dart/api/application/gallery/GalleryService.java
@@ -1,5 +1,7 @@
 package luckyseven.dart.api.application.gallery;
 
+import static luckyseven.dart.global.common.util.GlobalConstant.*;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -36,14 +38,20 @@ public class GalleryService {
 	private final S3Service s3Service;
 
 	public void createGallery(CreateGalleryDto createGalleryDto, MultipartFile thumbnail,
-		List<MultipartFile> imageFiles) throws IOException {
-		Cost cost = determineCost(createGalleryDto);
-		validateEndDateForPay(cost, createGalleryDto);
-		String thumbnailUrl = s3Service.uploadFile(thumbnail);
-		Gallery gallery = Gallery.create(createGalleryDto, thumbnailUrl, cost);
-		galleryRepository.save(gallery);
-		saveHashtags(createGalleryDto.hashTags(), gallery);
-		saveImages(createGalleryDto.images(), imageFiles, gallery);
+		List<MultipartFile> imageFiles) {
+		try {
+			validateImageCount(createGalleryDto);
+			validateImageFileCount(createGalleryDto, imageFiles);
+			final Cost cost = determineCost(createGalleryDto);
+			validateEndDateForPay(cost, createGalleryDto);
+			String thumbnailUrl = s3Service.uploadFile(thumbnail);
+			final Gallery gallery = Gallery.create(createGalleryDto, thumbnailUrl, cost);
+			galleryRepository.save(gallery);
+			saveHashtags(createGalleryDto.hashTags(), gallery);
+			saveImages(createGalleryDto.images(), imageFiles, gallery);
+		} catch (IOException e) {
+			throw new BadRequestException(ErrorCode.FAIL_INVALID_REQUEST);
+		}
 	}
 
 	public void deleteGallery(DeleteGalleryDto deleteGalleryDto) {
@@ -56,7 +64,8 @@ public class GalleryService {
 
 	private void saveHashtags(List<String> hashTags, Gallery gallery) {
 		if (hashTags != null) {
-			validateHashtags(hashTags);
+			validateHashtagsSize(hashTags);
+			validateHashTagsLength(hashTags);
 			List<Hashtag> hashtags = hashTags.stream()
 				.map(tag -> Hashtag.builder().tag(tag).gallery(gallery).build())
 				.collect(Collectors.toList());
@@ -64,26 +73,52 @@ public class GalleryService {
 		}
 	}
 
-	private void saveImages(List<ImageInfoDto> imageInfoDtos, List<MultipartFile> imageFiles, Gallery gallery) throws
-		IOException {
+	private void saveImages(List<ImageInfoDto> imageInfoDtos, List<MultipartFile> imageFiles, Gallery gallery) {
 		if (imageInfoDtos != null && !imageInfoDtos.isEmpty()) {
 			for (int i = 0; i < imageInfoDtos.size(); i++) {
 				ImageInfoDto imageInfoDto = imageInfoDtos.get(i);
 				MultipartFile imageFile = imageFiles.get(i);
-				String imageUrl = s3Service.uploadFile(imageFile);
-				Image image = Image.builder()
-					.imageUri(imageUrl)
-					.imageTitle(imageInfoDto.imageTitle())
-					.description(imageInfoDto.description())
-					.gallery(gallery)
-					.build();
-				imageRepository.save(image);
+				processImage(imageInfoDto, imageFile, gallery);
 			}
 		}
 	}
 
+	private void processImage(ImageInfoDto imageInfoDto, MultipartFile imageFile, Gallery gallery) {
+		try {
+			String imageUrl = s3Service.uploadFile(imageFile);
+			Image image = createImageEntity(imageInfoDto, imageUrl, gallery);
+			imageRepository.save(image);
+		} catch (IOException e) {
+			throw new BadRequestException(ErrorCode.FAIL_INVALID_REQUEST);
+		}
+	}
+
+	private Image createImageEntity(ImageInfoDto imageInfoDto, String imageUrl, Gallery gallery) {
+		return Image.builder()
+			.imageUri(imageUrl)
+			.imageTitle(imageInfoDto.imageTitle())
+			.description(imageInfoDto.description())
+			.gallery(gallery)
+			.build();
+	}
+
 	private Cost determineCost(CreateGalleryDto createGalleryDto) {
-		return createGalleryDto.fee() == 0 ? Cost.FREE : Cost.PAY;
+		if (createGalleryDto.fee() == ZERO) {
+			return Cost.FREE;
+		}
+		return Cost.PAY;
+	}
+
+	private void validateImageCount(CreateGalleryDto createGalleryDto) {
+		if (createGalleryDto.images().size() > TWENTY) {
+			throw new BadRequestException(ErrorCode.FAIL_EXHIBITION_ITEM_LIMIT_EXCEEDED);
+		}
+	}
+
+	private void validateImageFileCount(CreateGalleryDto createGalleryDto, List<MultipartFile> imageFiles) {
+		if (createGalleryDto.images().size() != imageFiles.size()) {
+			throw new BadRequestException(ErrorCode.FAIL_INVALID_EXHIBITION_ITEM_INFO);
+		}
 	}
 
 	private void validateEndDateForPay(Cost cost, CreateGalleryDto createGalleryDto) {
@@ -92,10 +127,13 @@ public class GalleryService {
 		}
 	}
 
-	private void validateHashtags(List<String> hashTags) {
-		if (hashTags.size() > 5) {
+	private void validateHashtagsSize(List<String> hashTags) {
+		if (hashTags.size() > FIVE) {
 			throw new BadRequestException(ErrorCode.FAIL_HASHTAG_SIZE_EXCEEDED);
 		}
+	}
+
+	private void validateHashTagsLength(List<String> hashTags) {
 		Pattern pattern = Pattern.compile("^[^\\s]{1,10}$");
 		boolean invalidTagFound = hashTags.parallelStream().anyMatch(tag -> !pattern.matcher(tag).matches());
 		if (invalidTagFound) {

--- a/src/main/java/luckyseven/dart/api/application/gallery/GalleryService.java
+++ b/src/main/java/luckyseven/dart/api/application/gallery/GalleryService.java
@@ -66,7 +66,7 @@ public class GalleryService {
 		if (hashTags != null) {
 			validateHashtagsSize(hashTags);
 			validateHashTagsLength(hashTags);
-			List<Hashtag> hashtags = hashTags.stream()
+			final List<Hashtag> hashtags = hashTags.stream()
 				.map(tag -> Hashtag.builder().tag(tag).gallery(gallery).build())
 				.collect(Collectors.toList());
 			hashtagRepository.saveAll(hashtags);
@@ -134,7 +134,7 @@ public class GalleryService {
 	}
 
 	private void validateHashTagsLength(List<String> hashTags) {
-		Pattern pattern = Pattern.compile("^[^\\s]{1,10}$");
+		final Pattern pattern = Pattern.compile("^[^\\s]{1,10}$");
 		boolean invalidTagFound = hashTags.parallelStream().anyMatch(tag -> !pattern.matcher(tag).matches());
 		if (invalidTagFound) {
 			throw new BadRequestException(ErrorCode.FAIL_TAG_CONTAINS_SPACE_OR_INVALID_LENGTH);

--- a/src/main/java/luckyseven/dart/api/domain/gallery/entity/Cost.java
+++ b/src/main/java/luckyseven/dart/api/domain/gallery/entity/Cost.java
@@ -1,8 +1,10 @@
 package luckyseven.dart.api.domain.gallery.entity;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public enum Cost {
 	ALL("전체", "all"),
@@ -17,32 +19,25 @@ public enum Cost {
 		this.value = value;
 	}
 
-	private static Map<String, Cost> names = new HashMap<>();
-	private static Map<String, Cost> valuesMap = new HashMap<>();
+	private static final Map<String, Cost> names = Collections.unmodifiableMap(Stream.of(values())
+		.collect(Collectors.toMap(Cost::getName, Function.identity())));
 
-	static {
-		for (Cost cost : Cost.values()) {
-			names.put(cost.name, cost);
-			valuesMap.put(cost.value, cost);
-		}
-		names = Collections.unmodifiableMap(names);
-		valuesMap = Collections.unmodifiableMap(valuesMap);
+	private static final Map<String, Cost> valuesMap = Collections.unmodifiableMap(Stream.of(values())
+		.collect(Collectors.toMap(Cost::getValue, Function.identity())));
+
+	private String getName() {
+		return name;
 	}
 
 	private String getValue() {
 		return value;
 	}
 
-	public static Cost fromValue(String value) {
-		return valuesMap.get(value);
+	public static boolean isValidCost(String value) {
+		return valuesMap.containsKey(value);
 	}
 
-	public static boolean isValidCost(String value) {
-		for (Cost cost : Cost.values()) {
-			if (cost.getValue().equalsIgnoreCase(value)) {
-				return true;
-			}
-		}
-		return false;
+	public static Cost fromValue(String value) {
+		return valuesMap.get(value);
 	}
 }

--- a/src/main/java/luckyseven/dart/api/domain/gallery/entity/Cost.java
+++ b/src/main/java/luckyseven/dart/api/domain/gallery/entity/Cost.java
@@ -1,0 +1,48 @@
+package luckyseven.dart.api.domain.gallery.entity;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public enum Cost {
+	ALL("전체", "all"),
+	FREE("무료", "free"),
+	PAY("유료", "pay");
+
+	private final String name;
+	private final String value;
+
+	Cost(String name, String value) {
+		this.name = name;
+		this.value = value;
+	}
+
+	private static Map<String, Cost> names = new HashMap<>();
+	private static Map<String, Cost> valuesMap = new HashMap<>();
+
+	static {
+		for (Cost cost : Cost.values()) {
+			names.put(cost.name, cost);
+			valuesMap.put(cost.value, cost);
+		}
+		names = Collections.unmodifiableMap(names);
+		valuesMap = Collections.unmodifiableMap(valuesMap);
+	}
+
+	private String getValue() {
+		return value;
+	}
+
+	public static Cost fromValue(String value) {
+		return valuesMap.get(value);
+	}
+
+	public static boolean isValidCost(String value) {
+		for (Cost cost : Cost.values()) {
+			if (cost.getValue().equalsIgnoreCase(value)) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/src/main/java/luckyseven/dart/api/domain/gallery/entity/Gallery.java
+++ b/src/main/java/luckyseven/dart/api/domain/gallery/entity/Gallery.java
@@ -15,12 +15,13 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import luckyseven.dart.api.dto.gallery.request.CreateGalleryDto;
+import luckyseven.dart.global.common.BaseTimeEntity;
 
 @Entity
 @Getter
 @Table(name = "tbl_gallery")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Gallery {
+public class Gallery extends BaseTimeEntity {
 	@Id
 	@Column(name = "id")
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/luckyseven/dart/api/domain/gallery/entity/Gallery.java
+++ b/src/main/java/luckyseven/dart/api/domain/gallery/entity/Gallery.java
@@ -4,25 +4,23 @@ import java.time.LocalDateTime;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import luckyseven.dart.api.domain.member.entity.Member;
-import luckyseven.dart.global.common.BaseTimeEntity;
+import luckyseven.dart.api.dto.gallery.request.CreateGalleryDto;
 
 @Entity
 @Getter
 @Table(name = "tbl_gallery")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Gallery extends BaseTimeEntity {
+public class Gallery {
 	@Id
 	@Column(name = "id")
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -34,11 +32,18 @@ public class Gallery extends BaseTimeEntity {
 	@Column(name = "content", nullable = false)
 	private String content;
 
+	@Column(name = "thumbnail", nullable = false)
+	private String thumbnail;
+
 	@Column(name = "start_date", nullable = false)
 	private LocalDateTime startDate;
 
-	@Column(name = "end_date", nullable = false)
+	@Column(name = "end_date")
 	private LocalDateTime endDate;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "cost", nullable = false)
+	private Cost cost;
 
 	@Column(name = "fee", nullable = false)
 	private int fee;
@@ -46,22 +51,41 @@ public class Gallery extends BaseTimeEntity {
 	@Column(name = "review_average")
 	private float reviewAverage;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "member_id")
-	private Member member;
+	@Column(name = "is_paid")
+	private boolean isPaid;
 
 	@Builder
 	private Gallery(
 		String title,
 		String content,
+		String thumbnail,
 		LocalDateTime startDate,
 		LocalDateTime endDate,
+		Cost cost,
 		int fee,
 		float reviewAverage
 	) {
 		this.title = title;
 		this.content = content;
+		this.thumbnail = thumbnail;
 		this.startDate = startDate;
+		this.cost = cost;
 		this.endDate = endDate;
+		this.fee = fee;
+		this.reviewAverage = reviewAverage;
+		this.isPaid = !Cost.PAY.equals(cost);
+	}
+
+	public static Gallery create(CreateGalleryDto createGalleryDto, String thumbnailUrl, Cost cost) {
+		return Gallery.builder()
+			.title(createGalleryDto.title())
+			.content(createGalleryDto.content())
+			.startDate(createGalleryDto.startDate())
+			.endDate(createGalleryDto.endDate())
+			.cost(cost)
+			.fee(createGalleryDto.fee())
+			.reviewAverage(0.0f)
+			.thumbnail(thumbnailUrl)
+			.build();
 	}
 }

--- a/src/main/java/luckyseven/dart/api/domain/gallery/entity/Hashtag.java
+++ b/src/main/java/luckyseven/dart/api/domain/gallery/entity/Hashtag.java
@@ -32,7 +32,8 @@ public class Hashtag {
 	private Gallery gallery;
 
 	@Builder
-	private Hashtag(
-		String tag
-	) { this.tag = tag; }
+	private Hashtag(String tag, Gallery gallery) {
+		this.tag = tag;
+		this.gallery = gallery;
+	}
 }

--- a/src/main/java/luckyseven/dart/api/domain/gallery/entity/Image.java
+++ b/src/main/java/luckyseven/dart/api/domain/gallery/entity/Image.java
@@ -27,8 +27,11 @@ public class Image {
 	@Column(name = "image_uri", nullable = false)
 	private String imageUri;
 
-	@Column(name = "thumbnail_uri")
-	private String thumbnailUri;
+	@Column(name = "image_title")
+	private String imageTitle;
+
+	@Column(name = "description")
+	private String description;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "gallery_id")
@@ -37,9 +40,13 @@ public class Image {
 	@Builder
 	private Image(
 		String imageUri,
-		String thumbnailUri
+		String imageTitle,
+		String description,
+		Gallery gallery
 	) {
 		this.imageUri = imageUri;
-		this.thumbnailUri = thumbnailUri;
+		this.imageTitle = imageTitle;
+		this.description = description;
+		this.gallery = gallery;
 	}
 }

--- a/src/main/java/luckyseven/dart/api/domain/gallery/repo/GalleryRepository.java
+++ b/src/main/java/luckyseven/dart/api/domain/gallery/repo/GalleryRepository.java
@@ -1,8 +1,10 @@
 package luckyseven.dart.api.domain.gallery.repo;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import luckyseven.dart.api.domain.gallery.entity.Gallery;
 
+@Repository
 public interface GalleryRepository extends JpaRepository<Gallery, Long> {
 }

--- a/src/main/java/luckyseven/dart/api/domain/gallery/repo/HashtagRepository.java
+++ b/src/main/java/luckyseven/dart/api/domain/gallery/repo/HashtagRepository.java
@@ -3,10 +3,12 @@ package luckyseven.dart.api.domain.gallery.repo;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import luckyseven.dart.api.domain.gallery.entity.Gallery;
 import luckyseven.dart.api.domain.gallery.entity.Hashtag;
 
+@Repository
 public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
 	List<Hashtag> findByGallery(Gallery gallery);
 }

--- a/src/main/java/luckyseven/dart/api/domain/gallery/repo/HashtagRepository.java
+++ b/src/main/java/luckyseven/dart/api/domain/gallery/repo/HashtagRepository.java
@@ -1,8 +1,12 @@
 package luckyseven.dart.api.domain.gallery.repo;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import luckyseven.dart.api.domain.gallery.entity.Gallery;
 import luckyseven.dart.api.domain.gallery.entity.Hashtag;
 
 public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
+	List<Hashtag> findByGallery(Gallery gallery);
 }

--- a/src/main/java/luckyseven/dart/api/domain/gallery/repo/ImageRepository.java
+++ b/src/main/java/luckyseven/dart/api/domain/gallery/repo/ImageRepository.java
@@ -3,10 +3,12 @@ package luckyseven.dart.api.domain.gallery.repo;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import luckyseven.dart.api.domain.gallery.entity.Gallery;
 import luckyseven.dart.api.domain.gallery.entity.Image;
 
+@Repository
 public interface ImageRepository extends JpaRepository<Image, Long> {
 	List<Image> findByGallery(Gallery gallery);
 }

--- a/src/main/java/luckyseven/dart/api/domain/gallery/repo/ImageRepository.java
+++ b/src/main/java/luckyseven/dart/api/domain/gallery/repo/ImageRepository.java
@@ -1,8 +1,12 @@
 package luckyseven.dart.api.domain.gallery.repo;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import luckyseven.dart.api.domain.gallery.entity.Gallery;
 import luckyseven.dart.api.domain.gallery.entity.Image;
 
 public interface ImageRepository extends JpaRepository<Image, Long> {
+	List<Image> findByGallery(Gallery gallery);
 }

--- a/src/main/java/luckyseven/dart/api/dto/gallery/request/CreateGalleryDto.java
+++ b/src/main/java/luckyseven/dart/api/dto/gallery/request/CreateGalleryDto.java
@@ -1,0 +1,23 @@
+package luckyseven.dart.api.dto.gallery.request;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CreateGalleryDto(
+	@NotBlank(message = "[❎ ERROR] 전시 제목을 입력해주세요.")
+	String title,
+	@NotBlank(message = "[❎ ERROR] 전시 설명을 입력해주세요.")
+	String content,
+	@NotNull(message = "[❎ ERROR] 전시 시작일을 입력해주세요.")
+	LocalDateTime startDate,
+	LocalDateTime endDate,
+	@NotNull(message = "[❎ ERROR] 전시 입장료를 입력해주세요.")
+	int fee,
+	List<String> hashTags,
+	@NotNull(message = "[❎ ERROR] 전시 작품들을 입력해주세요.")
+	List<ImageInfoDto> images
+) {
+}

--- a/src/main/java/luckyseven/dart/api/dto/gallery/request/DeleteGalleryDto.java
+++ b/src/main/java/luckyseven/dart/api/dto/gallery/request/DeleteGalleryDto.java
@@ -1,0 +1,9 @@
+package luckyseven.dart.api.dto.gallery.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record DeleteGalleryDto(
+	@NotNull(message = "[❎ ERROR] 삭제하고자 하는 전시의 아이디 값을 입력해주세요.")
+	Long galleryId
+) {
+}

--- a/src/main/java/luckyseven/dart/api/dto/gallery/request/ImageInfoDto.java
+++ b/src/main/java/luckyseven/dart/api/dto/gallery/request/ImageInfoDto.java
@@ -1,0 +1,7 @@
+package luckyseven.dart.api.dto.gallery.request;
+
+public record ImageInfoDto(
+	String imageTitle,
+	String description
+) {
+}

--- a/src/main/java/luckyseven/dart/global/common/util/GlobalConstant.java
+++ b/src/main/java/luckyseven/dart/global/common/util/GlobalConstant.java
@@ -1,0 +1,12 @@
+package luckyseven.dart.global.common.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class GlobalConstant {
+	public static final String BLANK = "";
+	public static final int FIVE = 5;
+	public static final int ZERO = 0;
+	public static final int TWENTY = 20;
+}

--- a/src/main/java/luckyseven/dart/global/common/util/GlobalConstant.java
+++ b/src/main/java/luckyseven/dart/global/common/util/GlobalConstant.java
@@ -6,7 +6,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class GlobalConstant {
 	public static final String BLANK = "";
-	public static final int FIVE = 5;
-	public static final int ZERO = 0;
-	public static final int TWENTY = 20;
+	public static final int MAX_HASHTAG_SIZE = 5;
+	public static final int PAYMENT_REQUIRED = 0;
+	public static final int MAX_IMAGE_SIZE = 20;
 }

--- a/src/main/java/luckyseven/dart/global/common/util/S3Service.java
+++ b/src/main/java/luckyseven/dart/global/common/util/S3Service.java
@@ -1,0 +1,57 @@
+package luckyseven.dart.global.common.util;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+	private final AmazonS3Client amazonS3;
+
+	@Value("${cloud.aws.s3.bucket}")
+	private String bucket;
+
+	public String uploadFile(MultipartFile multipartFile) throws IOException {
+		String originalFilename = multipartFile.getOriginalFilename();
+		String fileName = UUID.randomUUID().toString() + "_" + originalFilename;
+
+		ObjectMetadata metadata = new ObjectMetadata();
+		metadata.setContentLength(multipartFile.getSize());
+		metadata.setContentType(multipartFile.getContentType());
+
+		amazonS3.putObject(new PutObjectRequest(bucket, fileName, multipartFile.getInputStream(), metadata));
+		return amazonS3.getUrl(bucket, fileName).toString();
+	}
+
+	public void deleteFile(String fileUrl) {
+		String fileKey = extractFileKeyFromUrl(fileUrl);
+		amazonS3.deleteObject(new DeleteObjectRequest(bucket, fileKey));
+	}
+
+	private String extractFileKeyFromUrl(String fileUrl) {
+		try {
+			URL url = new URL(fileUrl);
+			String path = url.getPath();
+			String decodedPath = URLDecoder.decode(path, StandardCharsets.UTF_8);
+			return decodedPath.substring(1);
+		} catch (MalformedURLException e) {
+			throw new IllegalArgumentException("Invalid file URL: " + fileUrl, e);
+		}
+	}
+}

--- a/src/main/java/luckyseven/dart/global/config/S3Config.java
+++ b/src/main/java/luckyseven/dart/global/config/S3Config.java
@@ -1,0 +1,34 @@
+package luckyseven.dart.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+@Configuration
+public class S3Config {
+
+	@Value("${cloud.aws.credentials.access-key}")
+	private String accessKey;
+
+	@Value("${cloud.aws.credentials.secret-key}")
+	private String secretKey;
+
+	@Value("${cloud.aws.region.static}")
+	private String region;
+
+	@Bean
+	public AmazonS3Client amazonS3Client() {
+		BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+		return (AmazonS3Client)AmazonS3ClientBuilder
+			.standard()
+			.withRegion(region)
+			.withCredentials(new AWSStaticCredentialsProvider(credentials))
+			.build();
+	}
+}

--- a/src/main/java/luckyseven/dart/global/error/model/ErrorCode.java
+++ b/src/main/java/luckyseven/dart/global/error/model/ErrorCode.java
@@ -19,6 +19,10 @@ public enum ErrorCode {
 	FAIL_INVALID_EMAIL_FORMAT("[❎ ERROR] 잘못된 형식의 이메일입니다. 올바른 이메일을 입력해 주세요."),
 	FAIL_INVALID_PASSWORD_FORMAT("[❎ ERROR] 잘못된 형식의 비밀번호입니다. 비밀번호 규칙을 확인해 주세요."),
 	FAIL_INVALID_NICKNAME_FORMAT("[❎ ERROR] 잘못된 형식의 닉네임입니다. 닉네임 규칙을 확인해 주세요."),
+	FAIL_NECESSARY_THUMBNAIL("[❎ ERROR] 썸네일 이미지가 필요합니다."),
+	FAIL_HASHTAG_SIZE_EXCEEDED("[❎ ERROR] 해시태그 생성 가능 개수를 초과하였습니다. 해시태그는 최대 5개까지 생성 가능합니다."),
+	FAIL_TAG_CONTAINS_SPACE_OR_INVALID_LENGTH("해시태그는 공백 없이 10자까지 문자로만 생성이 가능합니다. "),
+	FAIL_INVALID_END_DATE_FOR_PAY("[❎ ERROR] 유료 전시의 경우 종료일을 입력해야 합니다."),
 
 	// 401 Unauthorized
 	FAIL_LOGIN_REQUIRED("[❎ ERROR] 로그인이 필요한 기능입니다."),
@@ -32,7 +36,7 @@ public enum ErrorCode {
 	FAIL_COMMENT_DELETION_FORBIDDEN("[❎ ERROR] 댓글 삭제 권한이 없습니다."),
 
 	// 404 Not Found
-	FAIL_POST_NOT_FOUND("[❎ ERROR] 요청하신 게시글을 찾을 수 없습니다."),
+	FAIL_GALLERY_NOT_FOUND("[❎ ERROR] 요청하신 전시관을 찾을 수 없습니다."),
 	FAIL_USER_NOT_FOUND("[❎ ERROR] 요청하신 회원을 찾을 수 없습니다."),
 	FAIL_COMMENT_NOT_FOUND("[❎ ERROR] 요청하신 댓글을 찾을 수 없습니다."),
 	FAIL_TOKEN_NOT_FOUND("[❎ ERROR] 요청하신 토큰을 찾을 수 없습니다."),
@@ -44,7 +48,6 @@ public enum ErrorCode {
 
 	// 500 Server Error
 	FAIL_INTERNAL_SERVER_ERROR("[❎ ERROR] 서버 내부 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
-
 
 	private String message;
 }

--- a/src/main/java/luckyseven/dart/global/error/model/ErrorCode.java
+++ b/src/main/java/luckyseven/dart/global/error/model/ErrorCode.java
@@ -21,8 +21,10 @@ public enum ErrorCode {
 	FAIL_INVALID_NICKNAME_FORMAT("[❎ ERROR] 잘못된 형식의 닉네임입니다. 닉네임 규칙을 확인해 주세요."),
 	FAIL_NECESSARY_THUMBNAIL("[❎ ERROR] 썸네일 이미지가 필요합니다."),
 	FAIL_HASHTAG_SIZE_EXCEEDED("[❎ ERROR] 해시태그 생성 가능 개수를 초과하였습니다. 해시태그는 최대 5개까지 생성 가능합니다."),
-	FAIL_TAG_CONTAINS_SPACE_OR_INVALID_LENGTH("해시태그는 공백 없이 10자까지 문자로만 생성이 가능합니다. "),
+	FAIL_TAG_CONTAINS_SPACE_OR_INVALID_LENGTH("[❎ ERROR] 해시태그는 공백 없이 10자까지 문자로만 생성이 가능합니다. "),
 	FAIL_INVALID_END_DATE_FOR_PAY("[❎ ERROR] 유료 전시의 경우 종료일을 입력해야 합니다."),
+	FAIL_EXHIBITION_ITEM_LIMIT_EXCEEDED("[❎ ERROR] 전시 작품은 최대 20개까지 생성 가능합니다."),
+	FAIL_INVALID_EXHIBITION_ITEM_INFO("[❎ ERROR] 전시 작품에 대한 정보를 잘못 입력하셨습니다."),
 
 	// 401 Unauthorized
 	FAIL_LOGIN_REQUIRED("[❎ ERROR] 로그인이 필요한 기능입니다."),

--- a/src/main/java/luckyseven/dart/presentation/GalleryController.java
+++ b/src/main/java/luckyseven/dart/presentation/GalleryController.java
@@ -1,9 +1,7 @@
 package luckyseven.dart.presentation;
 
-import java.io.IOException;
 import java.util.List;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -32,20 +30,8 @@ public class GalleryController {
 		@RequestPart("gallery") @Validated CreateGalleryDto createGalleryDto,
 		@RequestPart("thumbnail") MultipartFile thumbnail,
 		@RequestPart("images") List<MultipartFile> imageFiles) {
-		try {
-			if (createGalleryDto.images().size() > 20) {
-				return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-					.body("[❎ ERROR] 전시 작품은 최대 20개까지 생성 가능합니다.");
-			}
-			if (createGalleryDto.images().size() != imageFiles.size()) {
-				return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-					.body("[❎ ERROR] 전시 작품에 대한 정보를 잘못 입력하셨습니다.");
-			}
-			galleryService.createGallery(createGalleryDto, thumbnail, imageFiles);
-			return ResponseEntity.ok("ok");
-		} catch (IOException e) {
-			return ResponseEntity.status(500).body("File upload error: " + e.getMessage());
-		}
+		galleryService.createGallery(createGalleryDto, thumbnail, imageFiles);
+		return ResponseEntity.ok("ok");
 	}
 
 	@DeleteMapping

--- a/src/main/java/luckyseven/dart/presentation/GalleryController.java
+++ b/src/main/java/luckyseven/dart/presentation/GalleryController.java
@@ -1,0 +1,57 @@
+package luckyseven.dart.presentation;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.RequiredArgsConstructor;
+import luckyseven.dart.api.application.gallery.GalleryService;
+import luckyseven.dart.api.dto.gallery.request.CreateGalleryDto;
+import luckyseven.dart.api.dto.gallery.request.DeleteGalleryDto;
+
+@RestController
+@RequestMapping("/api/galleries")
+@RequiredArgsConstructor
+public class GalleryController {
+
+	private final GalleryService galleryService;
+
+	@PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+	public ResponseEntity<String> createGallery(
+		@RequestPart("gallery") @Validated CreateGalleryDto createGalleryDto,
+		@RequestPart("thumbnail") MultipartFile thumbnail,
+		@RequestPart("images") List<MultipartFile> imageFiles) {
+		try {
+			if (createGalleryDto.images().size() > 20) {
+				return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+					.body("[❎ ERROR] 전시 작품은 최대 20개까지 생성 가능합니다.");
+			}
+			if (createGalleryDto.images().size() != imageFiles.size()) {
+				return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+					.body("[❎ ERROR] 전시 작품에 대한 정보를 잘못 입력하셨습니다.");
+			}
+			galleryService.createGallery(createGalleryDto, thumbnail, imageFiles);
+			return ResponseEntity.ok("ok");
+		} catch (IOException e) {
+			return ResponseEntity.status(500).body("File upload error: " + e.getMessage());
+		}
+	}
+
+	@DeleteMapping
+	public ResponseEntity<String> deleteGalley(@RequestBody @Validated DeleteGalleryDto deleteGalleryDto) {
+		galleryService.deleteGallery(deleteGalleryDto);
+		return ResponseEntity.ok("ok");
+	}
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,7 @@
 spring:
   profiles:
     active: ${SPRING_PROFILES_ACTIVE}
+    include: secret
 
 server:
   port: 8080


### PR DESCRIPTION
## 📋 CheckList
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. feat: 유저 조회 기능 구현)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 이슈 번호 #19 

* close #19 

## 👩‍💻 공유 포인트 및 논의 사항
**전시 생성 시**
- 전시 제목, 전시 내용, 시작일, 종료일, 입장료, 썸네일 이미지, 해시태그들, 작품들(이미지, 제목, 설명)을 입력하면 전시가 생성이 됩니다.
- 해시태그는 한 전시에 최대 5개 생성이되며, 공백문자를 허용하지 않고 최대 10자까지 허용합니다.
- 이미지에는 무조건 제목과 설명이 입력되어야합니다. 
- 썸네일 이미지는 필수로 입력받아야합니다.
- 만일 전시 입장료가 0 이면 cost는 free로 저장이 되고, 0이 아니면 cost는 pay가 저장이 됩니다.
- 무료 전시라면 isPaid는 true값이 저장이 되고, 유료 전시라면 false입니다.
- 무료 전시라면 endDate값이 필수가 아닙니다. 유료 전시라면 endDate는 필수로 입력해야됩니다.

**전시 삭제 시** 
해당 전시에 대한 해시태그, 이미지 값들이 함께 삭제되며, s3에도 함께 삭제가 되도록 구현하였습니다.

**시큐리티가 적용되면 작동이 될 것 입니다. (모든 기능 테스트 완료 하였습니다.)**
제가 테스트할 때는 개인 aws에 버킷을 생성해서 했습니다. 