### PR TITLE
feat: 리뷰 조회 구현

### DIFF
--- a/src/main/java/luckyseven/dart/api/application/review/ReviewService.java
+++ b/src/main/java/luckyseven/dart/api/application/review/ReviewService.java
@@ -1,0 +1,29 @@
+package luckyseven.dart.api.application.review;
+
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import luckyseven.dart.api.domain.gallery.entity.Gallery;
+import luckyseven.dart.api.domain.gallery.repo.GalleryRepository;
+import luckyseven.dart.api.domain.review.entity.Review;
+import luckyseven.dart.api.domain.review.repo.ReviewRepository;
+import luckyseven.dart.dto.review.request.ReviewCreateDto;
+import luckyseven.dart.global.error.exception.NotFoundException;
+import luckyseven.dart.global.error.model.ErrorCode;
+
+@Transactional
+@RestController
+@RequiredArgsConstructor
+public class ReviewService {
+	private final ReviewRepository reviewRepository;
+	private final GalleryRepository galleryRepository;
+
+	public void create(ReviewCreateDto dto) {
+		final Gallery gallery = galleryRepository.findById(dto.galleryId())
+			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_GALLERY_NOT_FOUND));
+		final Review review = Review.create(dto, gallery);
+
+		reviewRepository.save(review);
+	}
+}

--- a/src/main/java/luckyseven/dart/api/application/review/ReviewService.java
+++ b/src/main/java/luckyseven/dart/api/application/review/ReviewService.java
@@ -1,5 +1,8 @@
 package luckyseven.dart.api.application.review;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -9,6 +12,8 @@ import luckyseven.dart.api.domain.gallery.repo.GalleryRepository;
 import luckyseven.dart.api.domain.review.entity.Review;
 import luckyseven.dart.api.domain.review.repo.ReviewRepository;
 import luckyseven.dart.dto.review.request.ReviewCreateDto;
+import luckyseven.dart.dto.review.response.PageInfo;
+import luckyseven.dart.dto.review.response.PageResponse;
 import luckyseven.dart.global.error.exception.NotFoundException;
 import luckyseven.dart.global.error.model.ErrorCode;
 
@@ -25,5 +30,16 @@ public class ReviewService {
 		final Review review = Review.create(dto, gallery);
 
 		reviewRepository.save(review);
+	}
+
+	@Transactional(readOnly = true)
+	public PageResponse readAll(Long galleryId, int page, int size) {
+		final Gallery gallery = galleryRepository.findById(galleryId)
+			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_GALLERY_NOT_FOUND));
+		final Pageable pageable = PageRequest.of(page, size);
+		final Page<Review> reviews = reviewRepository.findAllByGalleryOrderByCreatedAtDesc(gallery, pageable);
+		final PageInfo pageInfo = new PageInfo(reviews.getNumber(), reviews.isLast());
+
+		return new PageResponse(reviews.map(Review::toReviewReadDto).toList(), pageInfo);
 	}
 }

--- a/src/main/java/luckyseven/dart/api/domain/gallery/repo/GalleryRepository.java
+++ b/src/main/java/luckyseven/dart/api/domain/gallery/repo/GalleryRepository.java
@@ -1,8 +1,10 @@
 package luckyseven.dart.api.domain.gallery.repo;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import luckyseven.dart.api.domain.gallery.entity.Gallery;
 
+@Repository
 public interface GalleryRepository extends JpaRepository<Gallery, Long> {
 }

--- a/src/main/java/luckyseven/dart/api/domain/member/repo/MemberRepository.java
+++ b/src/main/java/luckyseven/dart/api/domain/member/repo/MemberRepository.java
@@ -1,8 +1,10 @@
 package luckyseven.dart.api.domain.member.repo;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import luckyseven.dart.api.domain.member.entity.Member;
 
+@Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 }

--- a/src/main/java/luckyseven/dart/api/domain/payment/repo/PaymentRepository.java
+++ b/src/main/java/luckyseven/dart/api/domain/payment/repo/PaymentRepository.java
@@ -1,8 +1,10 @@
 package luckyseven.dart.api.domain.payment.repo;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import luckyseven.dart.api.domain.payment.entity.Payment;
 
+@Repository
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
 }

--- a/src/main/java/luckyseven/dart/api/domain/review/entity/Review.java
+++ b/src/main/java/luckyseven/dart/api/domain/review/entity/Review.java
@@ -10,10 +10,12 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import luckyseven.dart.api.domain.gallery.entity.Gallery;
 import luckyseven.dart.api.domain.member.entity.Member;
+import luckyseven.dart.dto.review.request.ReviewCreateDto;
 
 @Entity
 @Getter
@@ -29,7 +31,7 @@ public class Review {
 	private String content;
 
 	@Column(name = "score")
-	private int score;
+	private Score score;
 
 	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "gallery_id")
@@ -39,4 +41,19 @@ public class Review {
 	@JoinColumn(name = "member_id")
 	private Member member;
 
+	@Builder
+	private Review(String content, Score score, Gallery gallery, Member member) {
+		this.content = content;
+		this.score = score;
+		this.gallery = gallery;
+		this.member = member;
+	}
+
+	public static Review create(ReviewCreateDto dto, Gallery gallery) {
+		return Review.builder()
+			.content(dto.content())
+			.score(Score.fromValue(dto.score()))
+			.gallery(gallery)
+			.build();
+	}
 }

--- a/src/main/java/luckyseven/dart/api/domain/review/entity/Review.java
+++ b/src/main/java/luckyseven/dart/api/domain/review/entity/Review.java
@@ -16,12 +16,14 @@ import lombok.NoArgsConstructor;
 import luckyseven.dart.api.domain.gallery.entity.Gallery;
 import luckyseven.dart.api.domain.member.entity.Member;
 import luckyseven.dart.dto.review.request.ReviewCreateDto;
+import luckyseven.dart.dto.review.response.ReviewReadDto;
+import luckyseven.dart.global.common.BaseTimeEntity;
 
 @Entity
 @Getter
 @Table(name = "tbl_review")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Review {
+public class Review extends BaseTimeEntity {
 	@Id
 	@Column(name = "id")
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -54,6 +56,16 @@ public class Review {
 			.content(dto.content())
 			.score(Score.fromValue(dto.score()))
 			.gallery(gallery)
+			.build();
+	}
+
+	public ReviewReadDto toReviewReadDto() {
+		return ReviewReadDto.builder()
+			.reviewId(this.id)
+			.content(this.content)
+			.score(this.score.getValue())
+			.createAt(this.getCreatedAt())
+			.nickname(this.member.getNickname())
 			.build();
 	}
 }

--- a/src/main/java/luckyseven/dart/api/domain/review/entity/Score.java
+++ b/src/main/java/luckyseven/dart/api/domain/review/entity/Score.java
@@ -1,0 +1,29 @@
+package luckyseven.dart.api.domain.review.entity;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Score {
+	ONE_STAR(1),
+	TWO_STAR(2),
+	THREE_STAR(3),
+	FOUR_STAR(4),
+	FIVE_STAR(5);
+
+	private final int value;
+
+	private static final Map<Integer, Score> valuesMap = Collections.unmodifiableMap(Stream.of(values())
+		.collect(Collectors.toMap(Score::getValue, Function.identity())));
+
+	public static Score fromValue(int value) {
+		return valuesMap.get(value);
+	}
+}

--- a/src/main/java/luckyseven/dart/api/domain/review/repo/ReviewRepository.java
+++ b/src/main/java/luckyseven/dart/api/domain/review/repo/ReviewRepository.java
@@ -1,10 +1,16 @@
 package luckyseven.dart.api.domain.review.repo;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import luckyseven.dart.api.domain.gallery.entity.Gallery;
 import luckyseven.dart.api.domain.review.entity.Review;
 
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+	//겔러리 최근 생성일 순
+	Page<Review> findAllByGalleryOrderByCreatedAtDesc(Gallery gallery, Pageable pageable);
 }

--- a/src/main/java/luckyseven/dart/api/domain/review/repo/ReviewRepository.java
+++ b/src/main/java/luckyseven/dart/api/domain/review/repo/ReviewRepository.java
@@ -1,8 +1,10 @@
 package luckyseven.dart.api.domain.review.repo;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import luckyseven.dart.api.domain.review.entity.Review;
 
+@Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 }

--- a/src/main/java/luckyseven/dart/dto/review/request/ReviewCreateDto.java
+++ b/src/main/java/luckyseven/dart/dto/review/request/ReviewCreateDto.java
@@ -1,0 +1,15 @@
+package luckyseven.dart.dto.review.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record ReviewCreateDto(
+	@NotNull(message = "[❎ ERROR] 전시회는 필수 입력 값입니다.")
+	Long galleryId,
+	String content,
+	@Min(value = 1, message = "[❎ ERROR] 점수는 1점 이상이어야 합니다.")
+	@Max(value = 5, message = "[❎ ERROR] 점수는 5점 이하여야 합니다.")
+	int score
+) {
+}

--- a/src/main/java/luckyseven/dart/dto/review/response/PageInfo.java
+++ b/src/main/java/luckyseven/dart/dto/review/response/PageInfo.java
@@ -1,0 +1,7 @@
+package luckyseven.dart.dto.review.response;
+
+public record PageInfo(
+	int pageIndex,
+	boolean isDone
+) {
+}

--- a/src/main/java/luckyseven/dart/dto/review/response/PageResponse.java
+++ b/src/main/java/luckyseven/dart/dto/review/response/PageResponse.java
@@ -1,0 +1,9 @@
+package luckyseven.dart.dto.review.response;
+
+import java.util.List;
+
+public record PageResponse(
+	List<ReviewReadDto> reviews,
+	PageInfo pageInfo
+) {
+}

--- a/src/main/java/luckyseven/dart/dto/review/response/ReviewReadDto.java
+++ b/src/main/java/luckyseven/dart/dto/review/response/ReviewReadDto.java
@@ -1,0 +1,16 @@
+package luckyseven.dart.dto.review.response;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+
+@Builder
+public record ReviewReadDto(
+	Long reviewId,
+	LocalDateTime createAt,
+	String content,
+	int score,
+	String nickname,
+	String profileImage
+) {
+}

--- a/src/main/java/luckyseven/dart/presentation/ReviewController.java
+++ b/src/main/java/luckyseven/dart/presentation/ReviewController.java
@@ -1,15 +1,19 @@
 package luckyseven.dart.presentation;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import luckyseven.dart.api.application.review.ReviewService;
 import luckyseven.dart.dto.review.request.ReviewCreateDto;
+import luckyseven.dart.dto.review.response.PageResponse;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,5 +26,14 @@ public class ReviewController {
 		reviewService.create(dto);
 
 		return ResponseEntity.ok("OK");
+	}
+
+	@GetMapping("/{gallery-id}")
+	public PageResponse readAll(
+		@PathVariable(name = "gallery-id") Long galleryId,
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "10") int size
+	) {
+		return reviewService.readAll(galleryId, page, size);
 	}
 }

--- a/src/main/java/luckyseven/dart/presentation/ReviewController.java
+++ b/src/main/java/luckyseven/dart/presentation/ReviewController.java
@@ -1,0 +1,24 @@
+package luckyseven.dart.presentation;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import luckyseven.dart.api.application.review.ReviewService;
+import luckyseven.dart.dto.review.request.ReviewCreateDto;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/reviews")
+public class ReviewController {
+	private final ReviewService reviewService;
+
+	@PostMapping
+	public ResponseEntity<String> create(ReviewCreateDto dto) {
+		reviewService.create(dto);
+
+		return ResponseEntity.ok("OK");
+	}
+}

--- a/src/main/java/luckyseven/dart/presentation/ReviewController.java
+++ b/src/main/java/luckyseven/dart/presentation/ReviewController.java
@@ -2,9 +2,11 @@ package luckyseven.dart.presentation;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import luckyseven.dart.api.application.review.ReviewService;
 import luckyseven.dart.dto.review.request.ReviewCreateDto;
@@ -16,7 +18,7 @@ public class ReviewController {
 	private final ReviewService reviewService;
 
 	@PostMapping
-	public ResponseEntity<String> create(ReviewCreateDto dto) {
+	public ResponseEntity<String> create(@RequestBody @Valid ReviewCreateDto dto) {
 		reviewService.create(dto);
 
 		return ResponseEntity.ok("OK");


### PR DESCRIPTION
## 📋 CheckList
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. feat: 유저 조회 기능 구현)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

* close #33 

## 👩‍💻 공유 포인트 및 논의 사항
* 리뷰 페이징 조회 서비스 구현입니다.
* 리뷰 엔티티에 있는 toReviewReadDto에 매개변수로 Review를 받지 않고, this를 사용한 이유를 말씀드리겠습니다.
* 서비스 단에서 페이징 Reviews를 받아서, 스트림으로 각각 분해하는데, 이 분해한 리뷰 엔티티 각자 고유한데, 매개변수에 review를 보내는 게 의미 없다고 생각해서 입니다. (불필요한 과정이라 생각이 들었습니다)
