### PR TITLE
fix: 닉네임 중복확인 에러 수정

### DIFF
--- a/src/main/java/com/dart/api/presentation/MemberController.java
+++ b/src/main/java/com/dart/api/presentation/MemberController.java
@@ -44,6 +44,15 @@ public class MemberController {
 		return ResponseEntity.ok("OK");
 	}
 
+	@PostMapping("/signup/nickname/check")
+	@ResponseStatus(HttpStatus.OK)
+	public ResponseEntity<String> checkNicknameDuplication(
+		@RequestBody NicknameDuplicationCheckDto nicknameDuplicationCheckDto) {
+		memberService.checkNicknameDuplication(nicknameDuplicationCheckDto);
+
+		return ResponseEntity.ok("OK");
+	}
+
 	@PostMapping("/login")
 	@ResponseStatus(HttpStatus.OK)
 	public ResponseEntity<LoginResDto> login(
@@ -64,15 +73,6 @@ public class MemberController {
 		@RequestPart @Valid MemberUpdateDto memberUpdateDto,
 		@RequestPart(name = "profileImage", required = false) MultipartFile profileImage) {
 		memberService.updateMemberProfile(authUser, memberUpdateDto, profileImage);
-		return ResponseEntity.ok("OK");
-	}
-
-	@PostMapping("/members/nickname/check")
-	@ResponseStatus(HttpStatus.OK)
-	public ResponseEntity<String> checkNicknameDuplication(
-		@RequestBody NicknameDuplicationCheckDto nicknameDuplicationCheckDto) {
-		memberService.checkNicknameDuplication(nicknameDuplicationCheckDto);
-
 		return ResponseEntity.ok("OK");
 	}
 }

--- a/src/main/java/com/dart/global/config/SecurityConfig.java
+++ b/src/main/java/com/dart/global/config/SecurityConfig.java
@@ -40,7 +40,7 @@ public class SecurityConfig {
 		return web -> web.ignoring()
 			.requestMatchers(PathRequest.toStaticResources().atCommonLocations())
 			.requestMatchers("/h2-console/**")
-			.requestMatchers("/api/signup")
+			.requestMatchers("/api/signup/**")
 			.requestMatchers("/api/email/**")
 			.requestMatchers("/api/payment/success/**")
 			.requestMatchers("/api/payment/fail")


### PR DESCRIPTION
## 📋 CheckList
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. feat: 유저 조회 기능 구현)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 #91 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

* close #91

## 👩‍💻 공유 포인트 및 논의 사항
* 닉네임 중복확인 기능을 회원정보 수정 기능에서도 사용하게 되며, api를 변경하였습니다. 
* /api/signup/nickname/check  ->  /api/nickname/check  (signup 제거함)
* 변경된 api를 토큰 없이 접근할 수 있도록 web.ignoring 에 추가하였습니다.
