### PR TITLE
미결제 전시관 자동삭제를 구현

### DIFF
--- a/src/main/java/com/dart/api/application/gallery/GalleryService.java
+++ b/src/main/java/com/dart/api/application/gallery/GalleryService.java
@@ -1,6 +1,7 @@
 package com.dart.api.application.gallery;
 
 import static com.dart.global.common.util.GlobalConstant.*;
+import static com.dart.global.common.util.PaymentConstant.*;
 
 import java.io.IOException;
 import java.util.List;
@@ -22,6 +23,7 @@ import com.dart.api.domain.member.entity.Member;
 import com.dart.api.domain.member.repository.MemberRepository;
 import com.dart.api.dto.gallery.request.CreateGalleryDto;
 import com.dart.api.dto.gallery.request.DeleteGalleryDto;
+import com.dart.global.common.util.RedisUtil;
 import com.dart.global.common.util.S3Service;
 import com.dart.global.error.exception.BadRequestException;
 import com.dart.global.error.exception.NotFoundException;
@@ -29,10 +31,12 @@ import com.dart.global.error.exception.UnauthorizedException;
 import com.dart.global.error.model.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class GalleryService {
 
 	private final MemberRepository memberRepository;
@@ -40,6 +44,7 @@ public class GalleryService {
 	private final HashtagRepository hashtagRepository;
 	private final ImageService imageService;
 	private final S3Service s3Service;
+	private final RedisUtil redisUtil;
 
 	public void createGallery(CreateGalleryDto createGalleryDto, MultipartFile thumbnail,
 		List<MultipartFile> imageFiles, AuthUser authUser) {
@@ -54,6 +59,7 @@ public class GalleryService {
 			galleryRepository.save(gallery);
 			saveHashtags(createGalleryDto.hashTags(), gallery);
 			imageService.saveImages(createGalleryDto.images(), imageFiles, gallery);
+			waitPayment(gallery);
 		} catch (IOException e) {
 			throw new BadRequestException(ErrorCode.FAIL_INVALID_REQUEST);
 		}
@@ -141,6 +147,16 @@ public class GalleryService {
 	private void validateUserOwnership(Member member, Gallery gallery) {
 		if (!Objects.equals(member.getId(), gallery.getMember().getId())) {
 			throw new BadRequestException(ErrorCode.FAIL_GALLERY_DELETION_FORBIDDEN);
+		}
+	}
+
+	private void waitPayment(Gallery gallery) {
+		if (!gallery.isPaid()) {
+			redisUtil.setDataExpire(
+				gallery.getId().toString(),
+				String.valueOf(gallery.getTitle()),
+				THIRTY_MINUTE
+			);
 		}
 	}
 }

--- a/src/main/java/com/dart/api/domain/gallery/repository/GalleryRepository.java
+++ b/src/main/java/com/dart/api/domain/gallery/repository/GalleryRepository.java
@@ -3,6 +3,7 @@ package com.dart.api.domain.gallery.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.dart.api.domain.gallery.entity.Gallery;
@@ -10,4 +11,7 @@ import com.dart.api.domain.gallery.entity.Gallery;
 @Repository
 public interface GalleryRepository extends JpaRepository<Gallery, Long> {
 	Page<Gallery> findAllByIsPaidTrue(Pageable pageable);
+
+	@Query("SELECT g.isPaid FROM Gallery g WHERE g.id = :id")
+	boolean findIsPaidById(Long id);
 }

--- a/src/main/java/com/dart/global/common/util/PaymentConstant.java
+++ b/src/main/java/com/dart/global/common/util/PaymentConstant.java
@@ -1,4 +1,4 @@
-package com.dart.global.common;
+package com.dart.global.common.util;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -15,4 +15,5 @@ public class PaymentConstant {
 	public static final String TAX = "0";
 	public static final String CID = "TC0ONETIME";
 	public static final String QUANTITY = "1";
+	public static final long THIRTY_MINUTE = 1800;
 }

--- a/src/main/java/com/dart/global/config/RedisConfig.java
+++ b/src/main/java/com/dart/global/config/RedisConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 
 import lombok.RequiredArgsConstructor;
@@ -24,6 +25,13 @@ public class RedisConfig {
 	@Bean
 	public RedisConnectionFactory redisConnectionFactory() {
 		return new LettuceConnectionFactory(host, port);
+	}
+
+	@Bean
+	public RedisMessageListenerContainer redisContainer(RedisConnectionFactory connectionFactory) {
+		RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+		container.setConnectionFactory(connectionFactory);
+		return container;
 	}
 
 	@Bean

--- a/src/main/java/com/dart/global/config/RedisKeyExpirationListener.java
+++ b/src/main/java/com/dart/global/config/RedisKeyExpirationListener.java
@@ -1,0 +1,57 @@
+package com.dart.global.config;
+
+import java.util.List;
+
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.listener.KeyExpirationEventMessageListener;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.dart.api.application.gallery.ImageService;
+import com.dart.api.domain.gallery.entity.Gallery;
+import com.dart.api.domain.gallery.entity.Hashtag;
+import com.dart.api.domain.gallery.repository.GalleryRepository;
+import com.dart.api.domain.gallery.repository.HashtagRepository;
+import com.dart.global.error.exception.NotFoundException;
+import com.dart.global.error.model.ErrorCode;
+
+@Component
+@Transactional
+public class RedisKeyExpirationListener extends KeyExpirationEventMessageListener {
+	private final GalleryRepository galleryRepository;
+	private final ImageService imageService;
+	private final HashtagRepository hashtagRepository;
+
+	public RedisKeyExpirationListener(
+		RedisMessageListenerContainer listenerContainer,
+		GalleryRepository galleryRepository,
+		ImageService imageService,
+		HashtagRepository hashtagRepository
+	) {
+		super(listenerContainer);
+		this.galleryRepository = galleryRepository;
+		this.imageService = imageService;
+		this.hashtagRepository = hashtagRepository;
+	}
+
+	@Override
+	public void onMessage(Message message, byte[] pattern) {
+		final String expiredKey = message.toString();
+
+		if (isLongParsable(expiredKey)) {
+			final Gallery gallery = galleryRepository.findById(Long.parseLong(expiredKey))
+				.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_GALLERY_NOT_FOUND));
+			final List<Hashtag> hashtags = hashtagRepository.findByGallery(gallery);
+
+			imageService.deleteImagesByGallery(gallery);
+			imageService.deleteThumbnail(gallery);
+			hashtagRepository.deleteAll(hashtags);
+			galleryRepository.delete(gallery);
+		}
+	}
+
+	public boolean isLongParsable(String str) {
+		return str != null && str.matches("-?\\d+");
+	}
+}

--- a/src/main/java/com/dart/global/error/model/ErrorCode.java
+++ b/src/main/java/com/dart/global/error/model/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
 	FAIL_ALREADY_CREATED_REVIEW("[❎ ERROR] 이미 리뷰를 작성하셨습니다."),
 	FAIL_NOT_VERIFIED_EMAIL("[❎ ERROR] 이메일 중복확인을 해주시길 바랍니다."),
 	FAIL_NOT_VERIFIED_NICKNAME("[❎ ERROR] 닉네임 중복확인을 해주시길 바랍니다."),
+	FAIL_NOT_PAYMENT_GALLERY("[❎ ERROR] 미결제 전시관입니다."),
 
 	// 401 Unauthorized
 	FAIL_LOGIN_REQUIRED("[❎ ERROR] 로그인이 필요한 기능입니다."),


### PR DESCRIPTION
## 📋 CheckList
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. feat: 유저 조회 기능 구현)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

* close #80 

## 👩‍💻 공유 포인트 및 논의 사항
* 유료 전시관을 생성만 하고 결제를 안 하면 의미없는 전시관이 생성됩니다.
* 사용자 결제 환경에 맞게, 30분 안에 결제를 안 한다면 자동 삭제하도록 구현했습니다.
* <흐름도>
* 1. 미결제 전시관 생성 -> MySQL과 Redis에 저장
* 2. 30분 안에 결제 성공 시 -> 레디스에서 삭제, Gallery 데이터 변경 (isPaid = true)
* 3. 30분 안에 결제 실패 시 -> 레디스 TTL 이벤트 발생, -> MySQL에서 데이터 삭제
