### PR TITLE
refactor: 사용자 정보 수정 기능 변경

### DIFF
--- a/src/main/java/com/dart/api/application/member/MemberService.java
+++ b/src/main/java/com/dart/api/application/member/MemberService.java
@@ -50,12 +50,15 @@ public class MemberService {
 
 	@Transactional
 	public void updateMemberProfile(AuthUser authUser, MemberUpdateDto memberUpdateDto, MultipartFile profileImage) {
+		validateNicknameChecked(memberUpdateDto.isCheckedNickname());
+
 		final Member member = findMemberByEmail(authUser.email());
-		nicknameValidator.validate(memberUpdateDto.nickname());
+		final String savedProfileImage = member.getProfileImageUrl();
 
 		try{
-			String profileImageUrl = s3Service.uploadFile(profileImage);
-			member.updateMemberProfile(memberUpdateDto, profileImageUrl);
+			String newProfileImageUrl = s3Service.uploadFile(profileImage);
+			if(savedProfileImage != null) s3Service.deleteFile(savedProfileImage);
+			member.updateMemberProfile(memberUpdateDto, newProfileImageUrl);
 		} catch (IOException e) {
 			throw new BadRequestException(ErrorCode.FAIL_INVALID_REQUEST);
 		}

--- a/src/main/java/com/dart/api/domain/member/entity/Member.java
+++ b/src/main/java/com/dart/api/domain/member/entity/Member.java
@@ -76,7 +76,6 @@ public class Member extends BaseTimeEntity {
 	}
 
 	public void updateMemberProfile(MemberUpdateDto memberUpdateDto, String profileImageUrl) {
-		this.nickname = memberUpdateDto.nickname();
 		this.profileImageUrl = profileImageUrl;
 		this.introduce = memberUpdateDto.introduce();
 	}

--- a/src/main/java/com/dart/api/dto/member/request/MemberUpdateDto.java
+++ b/src/main/java/com/dart/api/dto/member/request/MemberUpdateDto.java
@@ -1,18 +1,10 @@
 package com.dart.api.dto.member.request;
 
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
 @Builder
 public record MemberUpdateDto(
-	@Size(min = 2, max = 10, message = "[❎ ERROR] 닉네임은 2글자에서 10글자 사이여야 합니다.")
-	@Pattern(regexp = "^[A-Za-z\\d가-힣]+$", message = "[❎ ERROR] 닉네임은 한글과 영어만 사용가능합니다.")
-	String nickname,
-
-	String profileImage,
-	String bank,
-	String account,
+	boolean isCheckedNickname,
 	String introduce
 ) {
 }

--- a/src/main/java/com/dart/api/presentation/MemberController.java
+++ b/src/main/java/com/dart/api/presentation/MemberController.java
@@ -47,7 +47,7 @@ public class MemberController {
 	@PostMapping("/signup/nickname/check")
 	@ResponseStatus(HttpStatus.OK)
 	public ResponseEntity<String> checkNicknameDuplication(
-		@RequestBody NicknameDuplicationCheckDto nicknameDuplicationCheckDto) {
+		@RequestBody @Validated NicknameDuplicationCheckDto nicknameDuplicationCheckDto) {
 		memberService.checkNicknameDuplication(nicknameDuplicationCheckDto);
 
 		return ResponseEntity.ok("OK");

--- a/src/main/java/com/dart/api/presentation/MemberController.java
+++ b/src/main/java/com/dart/api/presentation/MemberController.java
@@ -44,6 +44,15 @@ public class MemberController {
 		return ResponseEntity.ok("OK");
 	}
 
+	@PostMapping("/signup/nickname/check")
+	@ResponseStatus(HttpStatus.OK)
+	public ResponseEntity<String> checkNicknameDuplication(
+		@RequestBody NicknameDuplicationCheckDto nicknameDuplicationCheckDto) {
+		memberService.checkNicknameDuplication(nicknameDuplicationCheckDto);
+
+		return ResponseEntity.ok("OK");
+	}
+
 	@PostMapping("/login")
 	@ResponseStatus(HttpStatus.OK)
 	public ResponseEntity<LoginResDto> login(
@@ -64,15 +73,6 @@ public class MemberController {
 		@RequestPart @Valid MemberUpdateDto memberUpdateDto,
 		@RequestPart(name = "profileImage", required = false) MultipartFile profileImage) {
 		memberService.updateMemberProfile(authUser, memberUpdateDto, profileImage);
-		return ResponseEntity.ok("OK");
-	}
-
-	@PostMapping("/members/nickname/check")
-	@ResponseStatus(HttpStatus.OK)
-	public ResponseEntity<String> checkNicknameDuplication(
-		@RequestBody NicknameDuplicationCheckDto nicknameDuplicationCheckDto) {
-		memberService.checkNicknameDuplication(nicknameDuplicationCheckDto);
-
 		return ResponseEntity.ok("OK");
 	}
 }

--- a/src/main/java/com/dart/global/config/SecurityConfig.java
+++ b/src/main/java/com/dart/global/config/SecurityConfig.java
@@ -42,6 +42,7 @@ public class SecurityConfig {
 			.requestMatchers("/h2-console/**")
 			.requestMatchers("/api/signup/**")
 			.requestMatchers("/api/email/**")
+			.requestMatchers("/api/nickname/check")
 			.requestMatchers("/api/payment/success/**")
 			.requestMatchers("/api/payment/fail")
 			.requestMatchers("/api/payment/cancel")

--- a/src/main/java/com/dart/global/config/SecurityConfig.java
+++ b/src/main/java/com/dart/global/config/SecurityConfig.java
@@ -40,7 +40,7 @@ public class SecurityConfig {
 		return web -> web.ignoring()
 			.requestMatchers(PathRequest.toStaticResources().atCommonLocations())
 			.requestMatchers("/h2-console/**")
-			.requestMatchers("/api/signup")
+			.requestMatchers("/api/signup/**")
 			.requestMatchers("/api/email/**")
 			.requestMatchers("/api/payment/success/**")
 			.requestMatchers("/api/payment/fail")

--- a/src/main/java/com/dart/global/config/WebConfig.java
+++ b/src/main/java/com/dart/global/config/WebConfig.java
@@ -21,7 +21,7 @@ public class WebConfig implements WebMvcConfigurer {
 	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/api/**")
 			.allowedOrigins(
-				"http://localhost:5173"
+				"https://localhost:5173"
 			)
 			.allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
 			.allowedHeaders("*")


### PR DESCRIPTION
## 📋 CheckList
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. feat: 유저 조회 기능 구현)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 #95  <!-- 이슈 번호를 작성해주세요 ex) #11 -->

* close #95

## 👩‍💻 공유 포인트 및 논의 사항
* 사용자 정보 수정시 닉네임, 자기소개, 프로필 이미지를 하나의 api로 수정하였습니다.
* 닉네임 중복확인이 불가하다는 문제가 발생하여, 닉네임 중복확인 api를 사용하였습니다.
* 기존의 정보 수정 요청 api에 존재하던 nickname을 isCheckedNickname으로 변경하였습니다.
* isCheckedNickname : 닉네임 중복확인 여부에 대한 boolean 값
