### PR TITLE
feat: 사용자 정보 조회 기능 수정

### DIFF
--- a/src/main/java/com/dart/api/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/dart/api/domain/member/repository/MemberRepository.java
@@ -9,5 +9,6 @@ import com.dart.api.domain.member.entity.Member;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 	boolean existsByNickname(String nickname);
 	Optional<Member> findByEmail(String email);
+	Optional<Member> findByNickname(String nickname);
 
 }

--- a/src/main/java/com/dart/api/dto/member/response/MemberProfileResDto.java
+++ b/src/main/java/com/dart/api/dto/member/response/MemberProfileResDto.java
@@ -4,6 +4,7 @@ public record MemberProfileResDto(
 	String email,
 	String nickname,
 	String profileImage,
+	String birthday,
 	String introduce
 ){
 

--- a/src/main/java/com/dart/api/presentation/MemberController.java
+++ b/src/main/java/com/dart/api/presentation/MemberController.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -52,10 +53,11 @@ public class MemberController {
 		return ResponseEntity.ok(authenticationService.login(loginReqDto, response));
 	}
 
-	@GetMapping("/members")
+	@GetMapping("/members/{nickname}")
 	@ResponseStatus(HttpStatus.OK)
-	public ResponseEntity<MemberProfileResDto> getMemberProfile(@Auth AuthUser authUser) {
-		return ResponseEntity.ok( memberService.getMemberProfile(authUser));
+	public ResponseEntity<MemberProfileResDto> getMemberProfile(
+		@PathVariable(name = "nickname") String nickname, @Auth AuthUser authUser) {
+		return ResponseEntity.ok( memberService.getMemberProfile(nickname, authUser));
 	}
 
 	@PutMapping("/members")


### PR DESCRIPTION
## 📋 CheckList
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. feat: 유저 조회 기능 구현)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [ ] 🧹 코드 스멜은 해결했나요?

## 🧩 #103  <!-- 이슈 번호를 작성해주세요 ex) #11 -->

* close #103

## 👩‍💻 공유 포인트 및 논의 사항
* 사용자 정보 조회시 닉네임을 path variable로 받습니다.
* 닉네임으로 자기 프로필 조회인지 타인 프로필 조회인지 구분합니다.
* 타인 프로필을 조회하는 경우, 생년월일에 null 값을 넣어 보내줍니다.
