### PR TITLE
refactor: 로그인 및 토큰 재발급 시 access token을 헤더 및 응답 본문에 전달

### DIFF
--- a/src/main/java/com/dart/api/dto/auth/request/EmailSendReqDto.java
+++ b/src/main/java/com/dart/api/dto/auth/request/EmailSendReqDto.java
@@ -1,12 +1,11 @@
-package com.dart.api.dto.auth;
+package com.dart.api.dto.auth.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
-public record EmailVerificationReqDto(
+public record EmailSendReqDto(
 	@Email
 	@NotBlank(message = "[❎ ERROR] 이메일을 입력해주세요.")
-	String email,
-	int code
+	String email
 ) {
 }

--- a/src/main/java/com/dart/api/dto/auth/request/EmailVerificationReqDto.java
+++ b/src/main/java/com/dart/api/dto/auth/request/EmailVerificationReqDto.java
@@ -1,11 +1,12 @@
-package com.dart.api.dto.auth;
+package com.dart.api.dto.auth.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
-public record EmailSendReqDto(
+public record EmailVerificationReqDto(
 	@Email
 	@NotBlank(message = "[❎ ERROR] 이메일을 입력해주세요.")
-	String email
+	String email,
+	int code
 ) {
 }

--- a/src/main/java/com/dart/api/dto/auth/response/TokenResDto.java
+++ b/src/main/java/com/dart/api/dto/auth/response/TokenResDto.java
@@ -1,0 +1,6 @@
+package com.dart.api.dto.auth.response;
+
+public record TokenResDto(
+	String accessToken
+) {
+}

--- a/src/main/java/com/dart/api/dto/member/response/LoginResDto.java
+++ b/src/main/java/com/dart/api/dto/member/response/LoginResDto.java
@@ -1,0 +1,6 @@
+package com.dart.api.dto.member.response;
+
+public record LoginResDto(
+	String accessToken
+) {
+}

--- a/src/main/java/com/dart/api/presentation/EmailController.java
+++ b/src/main/java/com/dart/api/presentation/EmailController.java
@@ -9,8 +9,8 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.dart.api.application.auth.EmailService;
-import com.dart.api.dto.auth.EmailSendReqDto;
-import com.dart.api.dto.auth.EmailVerificationReqDto;
+import com.dart.api.dto.auth.request.EmailSendReqDto;
+import com.dart.api.dto.auth.request.EmailVerificationReqDto;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/dart/api/presentation/MemberController.java
+++ b/src/main/java/com/dart/api/presentation/MemberController.java
@@ -17,10 +17,12 @@ import org.springframework.web.multipart.MultipartFile;
 import com.dart.api.application.auth.AuthenticationService;
 import com.dart.api.application.member.MemberService;
 import com.dart.api.domain.auth.entity.AuthUser;
+import com.dart.api.dto.auth.response.TokenResDto;
 import com.dart.api.dto.member.request.LoginReqDto;
 import com.dart.api.dto.member.request.MemberUpdateDto;
 import com.dart.api.dto.member.request.NicknameDuplicationCheckDto;
 import com.dart.api.dto.member.request.SignUpDto;
+import com.dart.api.dto.member.response.LoginResDto;
 import com.dart.api.dto.member.response.MemberProfileResDto;
 import com.dart.global.auth.annotation.Auth;
 
@@ -46,17 +48,15 @@ public class MemberController {
 
 	@PostMapping("/login")
 	@ResponseStatus(HttpStatus.OK)
-	public ResponseEntity<String> login(
+	public ResponseEntity<LoginResDto> login(
 		@RequestBody @Validated LoginReqDto loginReqDto, HttpServletResponse response) {
-		authenticationService.login(loginReqDto, response);
-		return ResponseEntity.ok("Login successfully");
+		return ResponseEntity.ok(authenticationService.login(loginReqDto, response));
 	}
 
 	@PostMapping("/reissue")
 	@ResponseStatus(HttpStatus.CREATED)
-	public ResponseEntity<String> reissue(HttpServletRequest request, HttpServletResponse response) {
-		authenticationService.reissue(request, response);
-		return ResponseEntity.ok("Token reissued successfully");
+	public ResponseEntity<TokenResDto> reissue(HttpServletRequest request, HttpServletResponse response) {
+		return ResponseEntity.ok(authenticationService.reissue(request, response));
 	}
 
 	@GetMapping("/members/{nickname}")

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -32,7 +32,7 @@ spring:
     database-platform: org.hibernate.dialect.MySQL8Dialect
     show-sql: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
 
   mail:
     host: ${SPRING_MAIL_HOST}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -68,6 +68,7 @@ jwt:
   secret:
     access-key: ${jwt.secret.access-key}
   access-expire: ${jwt.access-expire}
+  refresh-expire: ${jwt.refresh-expire}
 
 cloud:
   aws:


### PR DESCRIPTION
## 📋 CheckList
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. feat: 유저 조회 기능 구현)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 #116  <!-- 이슈 번호를 작성해주세요 ex) #11 -->

* close #116

## 👩‍💻 공유 포인트 및 논의 사항
* 변경 전 : 로그인 및 토큰 재발급시 access token을 header에 담아서 전달
* 변경 후 : 로그인 및 토큰 재발급시 access token을 header, response body에 담아서 전달
