### PR TITLE
feat: 갤러리 단건 조회 기능 추가

### DIFF
--- a/src/main/java/com/dart/api/application/gallery/ImageService.java
+++ b/src/main/java/com/dart/api/application/gallery/ImageService.java
@@ -2,6 +2,7 @@ package com.dart.api.application.gallery;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,6 +12,7 @@ import com.dart.api.domain.gallery.entity.Gallery;
 import com.dart.api.domain.gallery.entity.Image;
 import com.dart.api.domain.gallery.repository.ImageRepository;
 import com.dart.api.dto.gallery.request.ImageInfoDto;
+import com.dart.api.dto.gallery.response.ImageResDto;
 import com.dart.global.common.util.S3Service;
 import com.dart.global.error.exception.BadRequestException;
 import com.dart.global.error.model.ErrorCode;
@@ -64,5 +66,12 @@ public class ImageService {
 
 	public void deleteThumbnail(Gallery gallery) {
 		s3Service.deleteFile(gallery.getThumbnail());
+	}
+
+	@Transactional(readOnly = true)
+	public List<ImageResDto> getImagesByGalleryId(Long galleryId) {
+		return imageRepository.findByGalleryId(galleryId).stream()
+			.map(image -> new ImageResDto(image.getImageUri(), image.getDescription(), image.getImageTitle()))
+			.collect(Collectors.toList());
 	}
 }

--- a/src/main/java/com/dart/api/domain/gallery/repository/ImageRepository.java
+++ b/src/main/java/com/dart/api/domain/gallery/repository/ImageRepository.java
@@ -11,4 +11,6 @@ import com.dart.api.domain.gallery.entity.Image;
 @Repository
 public interface ImageRepository extends JpaRepository<Image, Long> {
 	List<Image> findByGallery(Gallery gallery);
+
+	List<Image> findByGalleryId(Long galleryId);
 }

--- a/src/main/java/com/dart/api/dto/gallery/response/GalleryResDto.java
+++ b/src/main/java/com/dart/api/dto/gallery/response/GalleryResDto.java
@@ -1,0 +1,10 @@
+package com.dart.api.dto.gallery.response;
+
+import java.util.List;
+
+public record GalleryResDto(
+	String title,
+	boolean hasComment,
+	List<ImageResDto> images
+) {
+}

--- a/src/main/java/com/dart/api/dto/gallery/response/ImageResDto.java
+++ b/src/main/java/com/dart/api/dto/gallery/response/ImageResDto.java
@@ -1,0 +1,8 @@
+package com.dart.api.dto.gallery.response;
+
+public record ImageResDto(
+	String image,
+	String description,
+	String imageTitle
+) {
+}

--- a/src/main/java/com/dart/api/presentation/GalleryController.java
+++ b/src/main/java/com/dart/api/presentation/GalleryController.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,6 +23,7 @@ import com.dart.api.dto.gallery.request.DeleteGalleryDto;
 import com.dart.api.dto.gallery.response.GalleryAllResDto;
 import com.dart.api.dto.gallery.response.GalleryInfoDto;
 import com.dart.api.dto.gallery.response.GalleryReadIdDto;
+import com.dart.api.dto.gallery.response.GalleryResDto;
 import com.dart.api.dto.page.PageResponse;
 import com.dart.global.auth.annotation.Auth;
 
@@ -62,6 +64,12 @@ public class GalleryController {
 		@Auth(required = false) AuthUser authUser
 	) {
 		return galleryService.getAllGalleries(page, size, category, keyword, sort, cost, display, authUser);
+	}
+
+	@GetMapping("/{gallery-id}")
+	public ResponseEntity<GalleryResDto> getGallery(
+		@PathVariable("gallery-id") Long galleryId, @Auth(required = false) AuthUser authUser) {
+		return ResponseEntity.ok(galleryService.getGallery(galleryId, authUser));
 	}
 
 	@GetMapping("/info")

--- a/src/main/java/com/dart/global/config/SecurityConfig.java
+++ b/src/main/java/com/dart/global/config/SecurityConfig.java
@@ -62,7 +62,7 @@ public class SecurityConfig {
 			.requestMatchers(HttpMethod.GET, "/api/login/oauth2/*").permitAll()
 			.requestMatchers(HttpMethod.POST, "/api/email/**").permitAll()
 			.requestMatchers("/favicon.ico").permitAll()
-			.requestMatchers(HttpMethod.GET, "/api/galleries").permitAll()
+			.requestMatchers(HttpMethod.GET, "/api/galleries/**").permitAll()
 			.requestMatchers(HttpMethod.GET, "/api/galleries/info").permitAll()
 			.anyRequest().authenticated()
 		);


### PR DESCRIPTION
## 📋 CheckList
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. feat: 유저 조회 기능 구현)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 이슈 번호 #108  -->

* close #108 

## 👩‍💻 공유 포인트 및 논의 사항
갤러리 아이디 PathVariable을 통해 조회 가능합니다.
갤러리 주인이라면 리뷰를 생성할 수 없기에 hasComment값은 true로 받았으며,
로그인안한 사용자는 hasComment값을 false로 받았습니다. (로그인을 한다면 생성이 가능하기 때문입니다.)
또, 로그인 했지만 갤러리 주인이 아니라면 리뷰가 있는지 검사하고 그 값을 받아오도록 구현완료하였습니다.
