### PR TITLE
deploy: GitHub Actions 배포 시 데아터베이스 초기화 및 중복 실행 이슈 해결

### DIFF
--- a/.github/workflows/pull-request-build.yml
+++ b/.github/workflows/pull-request-build.yml
@@ -1,9 +1,8 @@
 name: Build for Push & PR
 
 on:
-  push:
-    branches: [ "develop" ]
   pull_request:
+    types: [ "opened", "synchronize" ]
     branches: [ "develop" ]
 
 permissions:
@@ -12,7 +11,6 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, 'Merge') && github.event_name == 'push' || github.event_name == 'pull_request' && github.event.pull_request.merged == false"
 
     steps:
       - name: Checkout code

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     networks:
       - dart-network
     volumes:
-      - db_data:/var/lib/mysql
+      - ec2-user_db_data:/var/lib/mysql
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
       MYSQL_DATABASE: ${MYSQL_DATABASE}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,5 +66,5 @@ networks:
     driver: bridge
 
 volumes:
-  db_data:
+  ec2-user_db_data:
     driver: local


### PR DESCRIPTION
## 📋 CheckList
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. feat: 유저 조회 기능 구현)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

* close #168 

## 👩‍💻 공유 포인트 및 논의 사항
* GitHub Actions를 통해 배포를 진행할 때마다 데이터베이스가 초기화되지 않도록 설정을 변경했습니다.
* PR 생성과 Merge 생성 시 동작하는 GitHub Actions가 서로 중복으로 실행되지 않도록 파일을 수정했습니다.
