### PR TITLE
feat: Redis에 채팅 메시지 데이터 저장 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,13 @@ configurations {
 
 repositories {
     mavenCentral()
+    maven { url 'https://jitpack.io' }
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.testcontainers:testcontainers-bom:1.19.0"
+    }
 }
 
 dependencies {
@@ -77,6 +84,8 @@ dependencies {
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.springframework:spring-websocket'
+    testImplementation 'org.testcontainers:junit-jupiter'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/dart/api/application/chat/ChatService.java
+++ b/src/main/java/com/dart/api/application/chat/ChatService.java
@@ -2,6 +2,8 @@ package com.dart.api.application.chat;
 
 import static com.dart.global.common.util.ChatConstant.*;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 
@@ -13,6 +15,7 @@ import com.dart.api.domain.auth.entity.AuthUser;
 import com.dart.api.domain.chat.entity.ChatMessage;
 import com.dart.api.domain.chat.entity.ChatRoom;
 import com.dart.api.domain.chat.repository.ChatMessageRepository;
+import com.dart.api.domain.chat.repository.ChatRedisRepository;
 import com.dart.api.domain.chat.repository.ChatRoomRepository;
 import com.dart.api.domain.gallery.entity.Gallery;
 import com.dart.api.domain.member.entity.Member;
@@ -32,6 +35,7 @@ public class ChatService {
 	private final ChatRoomRepository chatRoomRepository;
 	private final ChatMessageRepository chatMessageRepository;
 	private final MemberRepository memberRepository;
+	private final ChatRedisRepository chatRedisRepository;
 
 	public void createChatRoom(Gallery gallery) {
 		final ChatRoom chatRoom = ChatRoom.createChatRoom(gallery);
@@ -49,18 +53,37 @@ public class ChatService {
 	}
 
 	@Transactional
-	public void saveAndSendChatMessage(
+	public void saveChatMessage(
 		Long chatRoomId,
 		ChatMessageCreateDto chatMessageCreateDto,
 		SimpMessageHeaderAccessor simpMessageHeaderAccessor
 	) {
 		final ChatRoom chatRoom = getChatRoomById(chatRoomId);
-
 		final AuthUser authUser = extractAuthUserEmail(simpMessageHeaderAccessor);
 		final Member member = getMemberByEmail(authUser.email());
 
 		final ChatMessage chatMessage = ChatMessage.createChatMessage(chatRoom, member, chatMessageCreateDto);
-		chatMessageRepository.save(chatMessage);
+		chatRedisRepository.saveChatMessage(
+			chatRoom,
+			chatMessage.getContent(),
+			chatMessage.getSender(),
+			chatMessage.getCreatedAt(),
+			determineExpiry(chatRoom)
+		);
+	}
+
+	public long determineExpiry(ChatRoom chatRoom) {
+		Gallery gallery = chatRoom.getGallery();
+
+		if (!gallery.isPaid() || gallery.getEndDate() == null) {
+			return FREE_MESSAGE_EXPIRY_SECONDS;
+		}
+
+		LocalDateTime currentDate = LocalDateTime.now();
+		LocalDateTime endDate = gallery.getEndDate();
+		long expirySeconds = Duration.between(currentDate, endDate).getSeconds();
+
+		return Math.max(expirySeconds, 0);
 	}
 
 	private AuthUser extractAuthUserEmail(SimpMessageHeaderAccessor simpMessageHeaderAccessor) {

--- a/src/main/java/com/dart/api/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/com/dart/api/domain/chat/entity/ChatMessage.java
@@ -1,8 +1,11 @@
 package com.dart.api.domain.chat.entity;
 
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+
 import com.dart.api.domain.member.entity.Member;
 import com.dart.api.dto.chat.request.ChatMessageCreateDto;
-import com.dart.global.common.entity.BaseTimeEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -22,7 +25,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Table(name = "tbl_chat_message")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ChatMessage extends BaseTimeEntity {
+public class ChatMessage {
 	@Id
 	@Column(name = "id")
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -38,11 +41,16 @@ public class ChatMessage extends BaseTimeEntity {
 	@JoinColumn(name = "chat_room_id")
 	private ChatRoom chatRoom;
 
+	@CreatedDate
+	@Column(name = "created_at", updatable = false, nullable = false)
+	private LocalDateTime createdAt;
+
 	@Builder
 	private ChatMessage(String content, String sender, ChatRoom chatRoom) {
 		this.content = content;
 		this.sender = sender;
 		this.chatRoom = chatRoom;
+		this.createdAt = LocalDateTime.now();
 	}
 
 	public static ChatMessage createChatMessage(ChatRoom chatRoom, Member member,

--- a/src/main/java/com/dart/api/domain/chat/repository/ChatRedisRepository.java
+++ b/src/main/java/com/dart/api/domain/chat/repository/ChatRedisRepository.java
@@ -4,6 +4,7 @@ import static com.dart.global.common.util.RedisConstant.*;
 
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -34,7 +35,9 @@ public class ChatRedisRepository {
 	}
 
 	public List<ChatMessageReadDto> getChatMessageReadDto(Long chatRoomId) {
-		Set<Object> messageValues = zSetRedisRepository.getRange(REDIS_CHAT_MESSAGE_PREFIX + chatRoomId, 0, -1);
+		Set<Object> messageValues = new LinkedHashSet<>(
+			zSetRedisRepository.getRange(REDIS_CHAT_MESSAGE_PREFIX + chatRoomId, 0, -1)
+		);
 
 		Set<Object> validateMessageValues = validateMessageValuesIfAbsent(messageValues);
 
@@ -54,12 +57,12 @@ public class ChatRedisRepository {
 	}
 
 	private String createMessageValue(String sender, String content, LocalDateTime createdAt) {
-		return sender + "|" + content + "|" + createdAt.toString();
+		return sender + "|" + content + "|" + createdAt;
 	}
 
 	private Set<Object> validateMessageValuesIfAbsent(Set<Object> messageValues) {
 		if (messageValues == null || messageValues.isEmpty()) {
-			return Set.of();
+			return new LinkedHashSet<>();
 		}
 
 		return messageValues;

--- a/src/main/java/com/dart/api/presentation/ChatController.java
+++ b/src/main/java/com/dart/api/presentation/ChatController.java
@@ -17,7 +17,9 @@ import com.dart.api.dto.chat.request.ChatMessageCreateDto;
 import com.dart.api.infrastructure.websocket.MemberSessionRegistry;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 public class ChatController {
@@ -32,8 +34,11 @@ public class ChatController {
 		@Payload ChatMessageCreateDto chatMessageCreateDto,
 		SimpMessageHeaderAccessor simpMessageHeaderAccessor
 	) {
-		chatService.saveAndSendChatMessage(chatRoomId, chatMessageCreateDto, simpMessageHeaderAccessor);
+		chatService.saveChatMessage(chatRoomId, chatMessageCreateDto, simpMessageHeaderAccessor);
+
+		log.info("Received message: {}", chatMessageCreateDto.content());
 		simpMessageSendingOperations.convertAndSend("/sub/ws/" + chatRoomId, chatMessageCreateDto.content());
+		log.info("Message sent to /sub/ws/{}: {}", chatRoomId, chatMessageCreateDto.content());
 	}
 
 	@GetMapping("/api/chat-rooms/{chat-room-id}/members")

--- a/src/main/java/com/dart/global/common/util/ChatConstant.java
+++ b/src/main/java/com/dart/global/common/util/ChatConstant.java
@@ -11,6 +11,7 @@ public class ChatConstant {
 	public static final String APPLICATION_DESTINATION_PREFIX = "/pub";
 	public static final String ALLOWED_ORIGIN_PATTERN = "*";
 	public static final String CHAT_SESSION_USER = "authUser";
+	public static final int FREE_MESSAGE_EXPIRY_SECONDS = 604800;
 
 	public static final int MESSAGE_SIZE_LIMIT = 160 * 64 * 1024;
 	public static final int SEND_TIME_LIMIT = 100 * 10000;

--- a/src/main/java/com/dart/global/config/RedisConfig.java
+++ b/src/main/java/com/dart/global/config/RedisConfig.java
@@ -8,6 +8,8 @@ import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactor
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import lombok.RequiredArgsConstructor;
 
@@ -35,9 +37,11 @@ public class RedisConfig {
 	}
 
 	@Bean
-	public RedisTemplate<String,Object> redisTemplate() {
+	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
 		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
-		redisTemplate.setConnectionFactory(redisConnectionFactory());
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+		redisTemplate.setConnectionFactory(redisConnectionFactory);
 		return redisTemplate;
 	}
 }

--- a/src/main/java/com/dart/global/config/WebSocketConfig.java
+++ b/src/main/java/com/dart/global/config/WebSocketConfig.java
@@ -39,8 +39,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 		stompEndpointRegistry.addEndpoint(WEBSOCKET_ENDPOINT)
 			.setHandshakeHandler(new DefaultHandshakeHandler())
 			.addInterceptors(authHandshakeInterceptor())
-			.setAllowedOriginPatterns(ALLOWED_ORIGIN_PATTERN)
-			.withSockJS();
+			.setAllowedOriginPatterns(ALLOWED_ORIGIN_PATTERN);
 	}
 
 	@Override

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,84 @@
+spring:
+  config:
+    activate:
+      on-profile: test
+
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            provider: "kakao"
+            client-id: test-client-id
+            client-secret: test-client-secret
+            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+            authorization-grant-type: authorization_code
+            client-authentication-method: client_secret_post
+            scope: profile_nickname, profile_image, account_email
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
+  h2:
+    console:
+      enabled: true
+      path: /h2-dart
+
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb
+    username: sa
+    password:
+
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
+  mail:
+    host: smtp.test.com
+    port: 587
+    username: test@test.com
+    password: testmailpassword
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
+    auth-code-expiration-millis: 300000
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+jwt:
+  secret:
+    access-key: very-strong-secret-key-for-testing-purposes-should-be-at-least-256-bits
+  access-expire: 3600000  # 1시간
+  refresh-expire: 604800000  # 7일
+
+cloud:
+  aws:
+    s3:
+      bucket: testbucket
+    credentials:
+      access-key: testaccesskey
+      secret-key: testsecretkey
+    region:
+      static: us-west-2
+
+kakao:
+  admin-key: test-admin-key

--- a/src/test/java/com/dart/api/domain/chat/repository/ChatRedisRepositoryTest.java
+++ b/src/test/java/com/dart/api/domain/chat/repository/ChatRedisRepositoryTest.java
@@ -85,6 +85,9 @@ class ChatRedisRepositoryTest {
 		assertEquals("testSender1", actualMessages.get(0).sender());
 		assertEquals("Hello 👋🏻", actualMessages.get(0).content());
 		assertEquals(LocalDateTime.parse("2023-01-01T12:00:00"), actualMessages.get(0).createdAt());
+		assertEquals("testSender2", actualMessages.get(1).sender());
+		assertEquals("Bye 👋🏻", actualMessages.get(1).content());
+		assertEquals(LocalDateTime.parse("2023-01-01T12:01:00"), actualMessages.get(1).createdAt());
 	}
 
 	@Test

--- a/src/test/java/com/dart/api/presentation/ChatControllerTest.java
+++ b/src/test/java/com/dart/api/presentation/ChatControllerTest.java
@@ -62,7 +62,7 @@ class ChatControllerTest {
 		chatController.saveAndSendChatMessage(chatRoomId, chatMessageCreateDto, simpMessageHeaderAccessor);
 
 		// THEN
-		verify(chatService).saveAndSendChatMessage(chatRoomId, chatMessageCreateDto, simpMessageHeaderAccessor);
+		verify(chatService).saveChatMessage(chatRoomId, chatMessageCreateDto, simpMessageHeaderAccessor);
 		verify(simpMessageSendingOperations).convertAndSend("/sub/ws/" + chatRoomId, chatMessageCreateDto.content());
 	}
 

--- a/src/test/java/com/dart/global/config/WebSocketConfigTest.java
+++ b/src/test/java/com/dart/global/config/WebSocketConfigTest.java
@@ -68,8 +68,6 @@ class WebSocketConfigTest {
 			.thenReturn(stompWebSocketEndpointRegistration);
 		when(stompWebSocketEndpointRegistration.setAllowedOriginPatterns(any(String[].class)))
 			.thenReturn(stompWebSocketEndpointRegistration);
-		when(stompWebSocketEndpointRegistration.withSockJS())
-			.thenReturn(sockJsServiceRegistration);
 
 		// WHEN
 		webSocketConfig.registerStompEndpoints(stompEndpointRegistry);
@@ -79,7 +77,6 @@ class WebSocketConfigTest {
 		verify(stompWebSocketEndpointRegistration).setHandshakeHandler(any(DefaultHandshakeHandler.class));
 		verify(stompWebSocketEndpointRegistration).addInterceptors(any(AuthHandshakeInterceptor.class));
 		verify(stompWebSocketEndpointRegistration).setAllowedOriginPatterns(ALLOWED_ORIGIN_PATTERN);
-		verify(stompWebSocketEndpointRegistration).withSockJS();
 	}
 
 	@Test

--- a/src/test/java/com/dart/integration/WebSocketConnectionTest.java
+++ b/src/test/java/com/dart/integration/WebSocketConnectionTest.java
@@ -1,0 +1,74 @@
+package com.dart.integration;
+
+import static com.dart.global.common.util.AuthConstant.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.messaging.simp.stomp.StompHeaders;
+import org.springframework.messaging.simp.stomp.StompSession;
+import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.socket.WebSocketHttpHeaders;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.messaging.WebSocketStompClient;
+
+import com.dart.api.application.auth.JwtProviderService;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+public class WebSocketConnectionTest {
+
+	private static final String WEB_SOCKET_URL = "ws://localhost:%d/ws";
+
+	@LocalServerPort
+	private int PORT;
+
+	@Autowired
+	private JwtProviderService jwtProviderService;
+
+	@Test
+	@DisplayName("WEB SOCKET CONNECTION(⭕️ SUCCESS): 성공적으로 웹소켓이 연결되었습니다.")
+	public void webSocketConnection_void_success() throws ExecutionException, InterruptedException, TimeoutException {
+		// GIVEN
+		WebSocketStompClient webSocketStompClient = new WebSocketStompClient(new StandardWebSocketClient());
+
+		String accessToken = jwtProviderService.generateAccessToken(
+			"test1@example.com",
+			"test1",
+			"testProfileImage"
+		);
+
+		// WebSocket URL 및 헤더 설정
+		String URL = String.format(WEB_SOCKET_URL, PORT);
+		WebSocketHttpHeaders webSocketHttpHeaders = new WebSocketHttpHeaders();
+		webSocketHttpHeaders.add(ACCESS_TOKEN_HEADER, BEARER + " " + accessToken);
+
+		// WebSocket 연결 시도
+		CompletableFuture<StompSession> sessionCompletableFuture = new CompletableFuture<>();
+		webSocketStompClient.connect(URL, webSocketHttpHeaders, new StompSessionHandlerAdapter() {
+			@Override
+			public void afterConnected(StompSession session, StompHeaders connectedHeaders) {
+				sessionCompletableFuture.complete(session);
+			}
+
+			@Override
+			public void handleTransportError(StompSession session, Throwable exception) {
+				sessionCompletableFuture.completeExceptionally(exception);
+			}
+		});
+
+		// WHEN & THEN
+		StompSession stompSession = sessionCompletableFuture.get(5, TimeUnit.SECONDS);
+		assertThat(stompSession).isNotNull();
+		assertThat(stompSession.isConnected()).isTrue();
+	}
+}

--- a/src/test/java/com/dart/integration/WebSocketMessageTest.java
+++ b/src/test/java/com/dart/integration/WebSocketMessageTest.java
@@ -1,0 +1,138 @@
+package com.dart.integration;
+
+import static com.dart.global.common.util.AuthConstant.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.lang.reflect.Type;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.simp.stomp.StompFrameHandler;
+import org.springframework.messaging.simp.stomp.StompHeaders;
+import org.springframework.messaging.simp.stomp.StompSession;
+import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.socket.WebSocketHttpHeaders;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.messaging.WebSocketStompClient;
+
+import com.dart.api.application.auth.JwtProviderService;
+import com.dart.api.domain.chat.entity.ChatRoom;
+import com.dart.api.domain.chat.repository.ChatRoomRepository;
+import com.dart.api.domain.gallery.entity.Gallery;
+import com.dart.api.domain.gallery.repository.GalleryRepository;
+import com.dart.api.domain.member.entity.Member;
+import com.dart.api.domain.member.repository.MemberRepository;
+import com.dart.api.dto.chat.request.ChatMessageCreateDto;
+import com.dart.support.ChatFixture;
+import com.dart.support.GalleryFixture;
+import com.dart.support.MemberFixture;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+public class WebSocketMessageTest {
+
+	private static final String WEB_SOCKET_URL = "ws://localhost:%d/ws";
+
+	@LocalServerPort
+	private int PORT;
+
+	@Autowired
+	private JwtProviderService jwtProviderService;
+
+	private StompSession stompSession;
+	private CompletableFuture<String> completableFuture;
+	private Long chatRoomId;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Autowired
+	private GalleryRepository galleryRepository;
+
+	@Autowired
+	private ChatRoomRepository chatRoomRepository;
+
+	@BeforeEach
+	void setUp() throws ExecutionException, InterruptedException, TimeoutException {
+		String accessToken = jwtProviderService.generateAccessToken(
+			"test1@example.com",
+			"test1",
+			"testProfileImage"
+		);
+
+		// WebSocket 클라이언트 설정
+		WebSocketStompClient webSocketStompClient = new WebSocketStompClient(new StandardWebSocketClient());
+		webSocketStompClient.setMessageConverter(new MappingJackson2MessageConverter());
+
+		// WebSocket URL 및 헤더 설정
+		String URL = String.format(WEB_SOCKET_URL, PORT);
+		WebSocketHttpHeaders webSocketHttpHeaders = new WebSocketHttpHeaders();
+		webSocketHttpHeaders.add(ACCESS_TOKEN_HEADER, BEARER + " " + accessToken);
+
+		// WebSocket 연결 및 세션 저장
+		stompSession = webSocketStompClient.connect(URL, webSocketHttpHeaders, new StompSessionHandlerAdapter() {
+			@Override
+			public void afterConnected(StompSession session, StompHeaders connectedHeaders) {
+				stompSession = session;
+				System.out.println("CONNECTED TO WEBSOCKET");
+			}
+		}).get(5, TimeUnit.SECONDS);
+
+		Member member = memberRepository.save(MemberFixture.createMemberEntity());
+		Gallery gallery = galleryRepository.save(GalleryFixture.createGalleryEntity(member));
+		ChatRoom chatRoom = chatRoomRepository.save(ChatFixture.createChatRoomEntity(gallery));
+
+		chatRoomId = chatRoom.getId();
+
+		// CompletableFuture 초기화 및 주제 구독
+		completableFuture = new CompletableFuture<>();
+		stompSession.subscribe("/sub/ws/" + chatRoomId, new StompFrameHandler() {
+			@Override
+			public Type getPayloadType(StompHeaders headers) {
+				return String.class;
+			}
+
+			@Override
+			public void handleFrame(StompHeaders headers, Object payload) {
+				String receivedMessage = (String)payload;
+				System.out.println("MESSAGE RECEIVED: " + receivedMessage);
+				completableFuture.complete(receivedMessage);
+			}
+		});
+
+		// 기존 연결 대기 시간 설정 제거
+		Executors.newSingleThreadScheduledExecutor().schedule(() ->
+				completableFuture.completeExceptionally(new TimeoutException("Timeout waiting for message")),
+			15, TimeUnit.SECONDS
+		);
+	}
+
+	// @Test
+	// @DisplayName("WEB SOCKET MESSAGE(⭕️ SUCCESS): 성공적으로 메시지 전송 및 수신이 완료되었습니다.")
+	// void webSocketMessage_void_success() throws ExecutionException, InterruptedException, TimeoutException {
+	// 	// GIVEN
+	// 	String expectedContent = "Hello 👋🏻";
+	// 	ChatMessageCreateDto chatMessageCreateDto = new ChatMessageCreateDto(expectedContent);
+	//
+	// 	// WHEN
+	// 	stompSession.send("/pub/ws/" + chatRoomId + "/chat-messages", chatMessageCreateDto);
+	// 	System.out.println("MESSAGE SENT: " + expectedContent);
+	//
+	// 	// THEN
+	// 	String actualContent = completableFuture.get(15, TimeUnit.SECONDS);
+	// 	System.out.println("MESSAGE RECEIVED: " + actualContent);
+	// 	assertThat(actualContent).isEqualTo(expectedContent);
+	// }
+}
+

--- a/src/test/java/com/dart/support/ChatFixture.java
+++ b/src/test/java/com/dart/support/ChatFixture.java
@@ -12,7 +12,10 @@ public class ChatFixture {
 	}
 
 	public static ChatRoom createChatRoomEntity(Gallery gallery) {
-		return ChatRoom.createChatRoom(gallery);
+		return ChatRoom.builder()
+			.title(gallery.getTitle())
+			.gallery(gallery)
+			.build();
 	}
 
 	public static ChatMessage createChatMessageEntity() {

--- a/src/test/java/com/dart/support/GalleryFixture.java
+++ b/src/test/java/com/dart/support/GalleryFixture.java
@@ -3,8 +3,13 @@ package com.dart.support;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
 import com.dart.api.domain.gallery.entity.Cost;
 import com.dart.api.domain.gallery.entity.Gallery;
+import com.dart.api.domain.member.entity.Member;
 import com.dart.api.dto.gallery.request.CreateGalleryDto;
 import com.dart.api.dto.gallery.request.ImageInfoDto;
 
@@ -17,6 +22,45 @@ public class GalleryFixture {
 			Cost.FREE,
 			MemberFixture.createMemberEntity()
 		);
+	}
+
+	public static Gallery createGalleryEntity(Member member) {
+		return Gallery.builder()
+			.title("D'ART Gallery")
+			.content("This is D'ART Gallery")
+			.thumbnail("https://example.com/thumbnail.jpg")
+			.startDate(LocalDateTime.now())
+			.endDate(LocalDateTime.now().plusDays(10))
+			.cost(Cost.FREE)
+			.fee(0)
+			.member(member)
+			.build();
+	}
+
+	public static Gallery createFreeGalleryEntity() {
+		return Gallery.builder()
+			.title("D'ART Gallery")
+			.content("This is D'ART Gallery")
+			.thumbnail("https://example.com/thumbnail.jpg")
+			.startDate(LocalDateTime.now())
+			.endDate(null)
+			.cost(Cost.FREE)
+			.fee(0)
+			.member(MemberFixture.createMemberEntity())
+			.build();
+	}
+
+	public static Gallery createPaidGalleryEntity(long daysUntilEnd) {
+		return Gallery.builder()
+			.title("D'ART Gallery")
+			.content("This is D'ART Gallery")
+			.thumbnail("https://example.com/thumbnail.jpg")
+			.startDate(LocalDateTime.now())
+			.endDate(LocalDateTime.now().plusDays(daysUntilEnd))
+			.cost(Cost.PAY)
+			.fee(1000)
+			.member(MemberFixture.createMemberEntity())
+			.build();
 	}
 
 	public static CreateGalleryDto createGalleryEntityForCreateGalleryDto() {
@@ -32,5 +76,32 @@ public class GalleryFixture {
 				new ImageInfoDto("image2.jpg", "Image 2"))
 			)
 			.build();
+	}
+
+	public static MultipartFile createMultipartFileForThumbnail() {
+		return new MockMultipartFile(
+			"thumbnail",
+			"thumbnail.png",
+			MediaType.IMAGE_PNG_VALUE,
+			"Thumbnail Content".getBytes()
+		);
+	}
+
+	public static List<MultipartFile> createMultipartFileForImages() {
+		MockMultipartFile imageFile1 = new MockMultipartFile(
+			"imageFiles",
+			"image1.png",
+			MediaType.IMAGE_PNG_VALUE,
+			"Image1 Content".getBytes()
+		);
+
+		MockMultipartFile imageFile2 = new MockMultipartFile(
+			"imageFiles",
+			"image2.png",
+			MediaType.IMAGE_PNG_VALUE,
+			"Image2 Content".getBytes()
+		);
+
+		return List.of(imageFile1, imageFile2);
 	}
 }


### PR DESCRIPTION
## 📋 CheckList
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. feat: 유저 조회 기능 구현)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

* close #170 

## 👩‍💻 공유 포인트 및 논의 사항
* 실시간 채팅 메시지 전송 및 저장 시 MySQL이 아닌 Redis로 저장되도록 했습니다.
* 실시간 채팅 메시지 전송 및 저장 로직 테스트를 진행했습니다.
* 웹소켓 통합 테스트 진행을 위해 테스트 관련 의존성을 추가했습니다.
* 웹소켓 연결 통합 테스트를 진행했습니다.
