### PR TITLE
fix: 이메일 인증코드 오인식 문제 해결

### DIFF
--- a/src/main/java/com/dart/api/dto/auth/request/EmailVerificationReqDto.java
+++ b/src/main/java/com/dart/api/dto/auth/request/EmailVerificationReqDto.java
@@ -7,6 +7,7 @@ public record EmailVerificationReqDto(
 	@Email
 	@NotBlank(message = "[❎ ERROR] 이메일을 입력해주세요.")
 	String email,
-	int code
+
+	String code
 ) {
 }

--- a/src/main/java/com/dart/global/common/util/CookieUtil.java
+++ b/src/main/java/com/dart/global/common/util/CookieUtil.java
@@ -33,9 +33,10 @@ public class CookieUtil {
 		setCookie(response, REFRESH_TOKEN_COOKIE_NAME, refreshToken, REFRESH_TOKEN_EXPIRATION_TIME_SECONDS);
 	}
 
-	public void setSessionCookie(HttpServletResponse response) {
+	public String setSessionCookie(HttpServletResponse response) {
 		String sessionId = UUID.randomUUID().toString();
 		setCookie(response, SESSION_ID, sessionId, SESSION_EXPIRATION_TIME_SECONDS);
+		return sessionId;
 	}
 
 	public String getCookie(HttpServletRequest request, String name) {


### PR DESCRIPTION
## 📋 CheckList
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. feat: 유저 조회 기능 구현)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 #199 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

* close #199

## 👩‍💻 공유 포인트 및 논의 사항
* 이메일 인증코드를 발급 받고 최초 입력하는 경우, 올바른 인증코드를 입력하였으나 다르다고 하는 문제 발생함.
* 최초 발급시 생성되는 쿠키값이 인식되지 않아 발생하는 문제라고 생각하였음.
* CookieUtil, EmailService 내의 관련 메소드를 수정하였음. 
