### PR TITLE
refactor: 웹소켓 인터셉터에서 URL 쿼리 파라미터로부터 토큰 추출

### DIFF
--- a/src/main/java/com/dart/global/common/util/ChatConstant.java
+++ b/src/main/java/com/dart/global/common/util/ChatConstant.java
@@ -16,4 +16,8 @@ public class ChatConstant {
 	public static final int MESSAGE_SIZE_LIMIT = 160 * 64 * 1024;
 	public static final int SEND_TIME_LIMIT = 100 * 10000;
 	public static final int SEND_BUFFER_SIZE_LIMIT = 3 * 512 * 1024;
+
+	public static final String TOKEN_PARAM = "token";
+	public static final String URL_QUERY_DELIMITER = "=";
+	public static final String QUERY_PARAM_SEPARATOR = "&";
 }


### PR DESCRIPTION
## 📋 CheckList
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. feat: 유저 조회 기능 구현)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

* close #209 

## 👩‍💻 공유 포인트 및 논의 사항
* AuthHandshakeInterceptor에서 ServerHttpRequest의 URL 쿼리 파라미터로부터 JWT 토큰을 추출하도록 했습니다.
* 토큰 검증 로직을 수정하여 URL에서 토큰을 추출하도록 수정했습니다.
