### PR TITLE
feat: HTTP와 HTTPS 모두에서 동작하도록 쿠키 설정 변경

### DIFF
--- a/src/main/java/com/dart/global/common/util/CookieUtil.java
+++ b/src/main/java/com/dart/global/common/util/CookieUtil.java
@@ -33,7 +33,6 @@ public class CookieUtil {
 			.domain(domain);
 
 		if(!isLocal) {
-			System.out.println("\n\nWow\n\n");
 			cookieBuilder.secure(true);
 		}
 
@@ -65,7 +64,6 @@ public class CookieUtil {
 	private boolean isLocalActiveProfile() {
 		for (String profile : env.getActiveProfiles()) {
 			if ("local".equals(profile)) {
-				System.out.println(profile);
 				return true;
 			}
 		}

--- a/src/main/java/com/dart/global/common/util/CookieUtil.java
+++ b/src/main/java/com/dart/global/common/util/CookieUtil.java
@@ -1,10 +1,11 @@
 package com.dart.global.common.util;
 
 import static com.dart.global.common.util.AuthConstant.*;
-import static com.dart.global.common.util.GlobalConstant.COOKIE_DOMAIN;
+import static com.dart.global.common.util.GlobalConstant.*;
 
 import java.util.UUID;
 
+import org.springframework.core.env.Environment;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
@@ -12,20 +13,31 @@ import org.springframework.stereotype.Component;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 
 @Component
+@RequiredArgsConstructor
 public class CookieUtil {
 
+	private final Environment env;
+
 	public void setCookie(HttpServletResponse response, String name, String value, long maxAgeSeconds){
-		ResponseCookie cookie = ResponseCookie.from(name, value)
+		boolean isLocal = isLocalActiveProfile();
+		String domain = isLocal ? LOCAL_DOMAIN : COOKIE_DOMAIN;
+
+		ResponseCookie.ResponseCookieBuilder cookieBuilder = ResponseCookie.from(name, value)
 			.httpOnly(true)
-			.secure(true)
 			.path("/")
 			.maxAge(maxAgeSeconds)
 			.sameSite("None")
-			.domain(COOKIE_DOMAIN)
-			.build();
+			.domain(domain);
 
+		if(!isLocal) {
+			System.out.println("\n\nWow\n\n");
+			cookieBuilder.secure(true);
+		}
+
+		ResponseCookie cookie = cookieBuilder.build();
 		response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 	}
 
@@ -48,5 +60,15 @@ public class CookieUtil {
 			}
 		}
 		return null;
+	}
+
+	private boolean isLocalActiveProfile() {
+		for (String profile : env.getActiveProfiles()) {
+			if ("local".equals(profile)) {
+				System.out.println(profile);
+				return true;
+			}
+		}
+		return false;
 	}
 }

--- a/src/main/java/com/dart/global/common/util/GlobalConstant.java
+++ b/src/main/java/com/dart/global/common/util/GlobalConstant.java
@@ -5,6 +5,7 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class GlobalConstant {
+	public static final String LOCAL_DOMAIN = "localhost";
 	public static final String COOKIE_DOMAIN = "dartgallery.site";
 	public static final String BLANK = "";
 	public static final int MAX_HASHTAG_SIZE = 5;


### PR DESCRIPTION
## 📋 CheckList
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. feat: 유저 조회 기능 구현)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 #218 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

* close #218

## 👩‍💻 공유 포인트 및 논의 사항
* 프로파일에 따라 쿠키의 `Secure` 속성을 설정하도록 수정했습니다.
* 로컬 환경에서는 `localhost` 도메인을, 배포 환경에서는 실제 도메인을 사용하여 쿠키를 설정했습니다.
