### PR TITLE
refactor: 무료 전시의 경우 hasTicket이 항상 true가 되도록 수정

### DIFF
--- a/src/main/java/com/dart/api/application/gallery/GalleryService.java
+++ b/src/main/java/com/dart/api/application/gallery/GalleryService.java
@@ -272,6 +272,10 @@ public class GalleryService {
 	}
 
 	private boolean checkIfUserHasTicket(AuthUser authUser, Gallery gallery) {
+		if (isFreeGallery(gallery)) {
+			return true;
+		}
+
 		if (isAuthUserNull(authUser)) {
 			return false;
 		}
@@ -301,6 +305,10 @@ public class GalleryService {
 
 	private boolean isAuthUserNull(AuthUser authUser) {
 		return authUser == null;
+	}
+
+	private boolean isFreeGallery(Gallery gallery) {
+		return gallery.getCost() == Cost.FREE;
 	}
 
 	private boolean isGalleryOwner(Gallery gallery, Member member) {


### PR DESCRIPTION
## 📋 CheckList
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. feat: 유저 조회 기능 구현)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 이슈 번호 #234 

* close #234

## 👩‍💻 공유 포인트 및 논의 사항
전시 단건 조회와 전시 정보 조회 시 사용되는 hasTicktet값이 무료 전시 일 경우 false였지만 로그인 비로그인과 관계없이 항상 true값을 가지도록 수정하였고, 유료 전시는 전과 같습니다.
