### PR TITLE
feat: SSE 알림 저장을 위한 알림 엔티티 모델 생성

### DIFF
--- a/src/main/java/com/dart/api/application/chat/ChatMessageService.java
+++ b/src/main/java/com/dart/api/application/chat/ChatMessageService.java
@@ -60,17 +60,14 @@ public class ChatMessageService {
 
 	@Transactional(readOnly = true)
 	public PageResponse<ChatMessageReadDto> getChatMessageList(Long chatRoomId, int page, int size) {
-		List<ChatMessageReadDto> chatMessageReadDtoList = new ArrayList<>();
-
 		PageResponse<ChatMessageReadDto> redisChatMessageReadDtoList = chatRedisRepository
 			.getChatMessageReadDto(chatRoomId, page, size);
 
-		if (redisChatMessageReadDtoList == null || redisChatMessageReadDtoList.pages().isEmpty()) {
-			chatMessageReadDtoList = fetchChatMessagesFromDBAndCache(chatRoomId, page, size);
-		} else {
-			chatMessageReadDtoList.addAll(redisChatMessageReadDtoList.pages());
+		if (redisChatMessageReadDtoList != null && !redisChatMessageReadDtoList.pages().isEmpty()) {
+			return createPageResponse(new ArrayList<>(redisChatMessageReadDtoList.pages()), page, size);
 		}
 
+		List<ChatMessageReadDto> chatMessageReadDtoList = fetchChatMessagesFromDBAndCache(chatRoomId, page, size);
 		return createPageResponse(chatMessageReadDtoList, page, size);
 	}
 

--- a/src/main/java/com/dart/api/domain/notification/entity/Notification.java
+++ b/src/main/java/com/dart/api/domain/notification/entity/Notification.java
@@ -1,0 +1,37 @@
+package com.dart.api.domain.notification.entity;
+
+import com.dart.global.common.entity.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "tbl_notification")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends BaseTimeEntity {
+	@Id
+	@Column(name = "id")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "message", nullable = false)
+	private String message;
+
+	@Column(name = "client_id", nullable = false)
+	private String clientId;
+
+	@Builder
+	private Notification(String message, String clientId) {
+		this.message = message;
+		this.clientId = clientId;
+	}
+}

--- a/src/main/java/com/dart/api/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/dart/api/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,11 @@
+package com.dart.api.domain.notification.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.dart.api.domain.notification.entity.Notification;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+}

--- a/src/main/java/com/dart/api/infrastructure/websocket/AuthChannelInterceptor.java
+++ b/src/main/java/com/dart/api/infrastructure/websocket/AuthChannelInterceptor.java
@@ -2,6 +2,9 @@ package com.dart.api.infrastructure.websocket;
 
 import static com.dart.global.common.util.AuthConstant.*;
 import static com.dart.global.common.util.ChatConstant.*;
+import static com.dart.global.common.util.GlobalConstant.*;
+
+import java.util.Objects;
 
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
@@ -23,39 +26,41 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class AuthChannelInterceptor implements ChannelInterceptor {
 
-	public static final String STOMP_COMMAND_HEADER = "stompCommand";
-
 	private final JwtProviderService jwtProviderService;
 
 	@Override
 	public Message<?> preSend(Message<?> message, MessageChannel channel) {
 		StompHeaderAccessor stompHeaderAccessor = StompHeaderAccessor.wrap(message);
 
-		final String authorizationHeader = String.valueOf(
-			stompHeaderAccessor.getFirstNativeHeader(ACCESS_TOKEN_HEADER));
-
-		final String command = String.valueOf(
-			stompHeaderAccessor.getHeader(STOMP_COMMAND_HEADER));
-
-		if (!command.equals("SEND")) {
+		if (!isSendCommand(stompHeaderAccessor)) {
 			return message;
 		}
 
-		if (authorizationHeader == null || authorizationHeader.equals("null")) {
-			throw new UnauthorizedException(ErrorCode.FAIL_LOGIN_REQUIRED);
-		}
+		final String authorizationHeader = stompHeaderAccessor.getFirstNativeHeader(ACCESS_TOKEN_HEADER);
+		final String token = extractToken(authorizationHeader);
+		validateAuthenticateToken(token);
 
-		final String token = authorizationHeader.substring(7);
-
-		try {
-			jwtProviderService.isUsable(token);
-			final AuthUser authUser = jwtProviderService.extractAuthUserByAccessToken(token);
-			stompHeaderAccessor.setHeader(CHAT_SESSION_USER, authUser);
-		} catch (Exception e) {
-			log.error("FAIL VALIDATE JWT TOKEN: {}", e.getMessage(), e);
-			throw new UnauthorizedException(ErrorCode.FAIL_INVALID_TOKEN);
-		}
+		final AuthUser authUser = jwtProviderService.extractAuthUserByAccessToken(token);
+		stompHeaderAccessor.setHeader(CHAT_SESSION_USER, authUser);
 
 		return message;
+	}
+
+	private boolean isSendCommand(StompHeaderAccessor stompHeaderAccessor) {
+		return Objects.equals(StompCommand.SEND, stompHeaderAccessor.getHeader(STOMP_COMMAND_HEADER));
+	}
+
+	private String extractToken(String authorizationHeader) {
+		if (authorizationHeader == null || !authorizationHeader.startsWith(BEARER)) {
+			return null;
+		}
+		return authorizationHeader.replaceFirst(BEARER, BLANK).trim();
+	}
+
+	private void validateAuthenticateToken(String token) {
+		if (token == null || !jwtProviderService.isUsable(token)) {
+			log.warn("[✅ LOGGER] INVALID OR MISSING JWT TOKEN");
+			throw new UnauthorizedException(ErrorCode.FAIL_TOKEN_EXPIRED_OR_INVALID);
+		}
 	}
 }

--- a/src/main/java/com/dart/api/presentation/ChatController.java
+++ b/src/main/java/com/dart/api/presentation/ChatController.java
@@ -20,9 +20,7 @@ import com.dart.api.dto.page.PageResponse;
 import com.dart.api.infrastructure.websocket.MemberSessionRegistry;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @RestController
 @RequiredArgsConstructor
 public class ChatController {
@@ -38,10 +36,7 @@ public class ChatController {
 		SimpMessageHeaderAccessor simpMessageHeaderAccessor
 	) {
 		chatMessageService.saveChatMessage(chatRoomId, chatMessageCreateDto, simpMessageHeaderAccessor);
-
-		log.info("Received message: {}", chatMessageCreateDto.content());
 		simpMessageSendingOperations.convertAndSend("/sub/ws/" + chatRoomId, chatMessageCreateDto.content());
-		log.info("Message sent to /sub/ws/{}: {}", chatRoomId, chatMessageCreateDto.content());
 	}
 
 	@GetMapping("/api/chat-rooms/{chat-room-id}/members")

--- a/src/main/java/com/dart/global/common/util/ChatConstant.java
+++ b/src/main/java/com/dart/global/common/util/ChatConstant.java
@@ -13,6 +13,7 @@ public class ChatConstant {
 	public static final String CHAT_SESSION_USER = "authUser";
 	public final static String SORT_FIELD_CREATED_AT = "createdAt";
 	public final static long CHAT_MESSAGE_EXPIRY_SECONDS = 60 * 60;
+	public static final String STOMP_COMMAND_HEADER = "stompCommand";
 
 	public static final int MESSAGE_SIZE_LIMIT = 160 * 64 * 1024;
 	public static final int SEND_TIME_LIMIT = 100 * 10000;

--- a/src/test/java/com/dart/api/infrastructure/websocket/AuthChannelInterceptorTest.java
+++ b/src/test/java/com/dart/api/infrastructure/websocket/AuthChannelInterceptorTest.java
@@ -1,0 +1,91 @@
+package com.dart.api.infrastructure.websocket;
+
+import static com.dart.global.common.util.AuthConstant.*;
+import static com.dart.global.common.util.ChatConstant.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+
+import com.dart.api.application.auth.JwtProviderService;
+import com.dart.api.domain.auth.entity.AuthUser;
+import com.dart.global.error.exception.UnauthorizedException;
+import com.dart.support.MemberFixture;
+
+@ExtendWith(MockitoExtension.class)
+class AuthChannelInterceptorTest {
+
+	@Mock
+	private JwtProviderService jwtProviderService;
+
+	@Mock
+	private MessageChannel messageChannel;
+
+	@InjectMocks
+	private AuthChannelInterceptor authChannelInterceptor;
+
+	@Test
+	@DisplayName("PRE SEND(⭕️ SUCCESS): 유효한 JWT 토큰이 제공되어 성공적으로 AuthUser를 설정했습니다.")
+	void preSend_void_success() {
+		// GIVEN
+		String expectedValidToken = "Bearer expectedValidToken";
+		String expectedAccessToken = expectedValidToken.substring(7);
+
+		StompHeaderAccessor stompHeaderAccessor = StompHeaderAccessor.create(StompCommand.SEND);
+		stompHeaderAccessor.addNativeHeader(ACCESS_TOKEN_HEADER, expectedValidToken);
+		stompHeaderAccessor.setHeader(STOMP_COMMAND_HEADER, StompCommand.SEND);
+		stompHeaderAccessor.setLeaveMutable(true);
+
+		Message<byte[]> expectedMessage = MessageBuilder.createMessage(
+			new byte[0],
+			stompHeaderAccessor.getMessageHeaders());
+
+		AuthUser authUser = MemberFixture.createAuthUserEntity();
+
+		when(jwtProviderService.isUsable(expectedAccessToken)).thenReturn(true);
+		when(jwtProviderService.extractAuthUserByAccessToken(expectedAccessToken)).thenReturn(authUser);
+
+		// WHEN
+		authChannelInterceptor.preSend(expectedMessage, messageChannel);
+
+		// THEN
+		verify(jwtProviderService).isUsable(expectedAccessToken);
+		verify(jwtProviderService).extractAuthUserByAccessToken(expectedAccessToken);
+	}
+
+	@Test
+	@DisplayName("PRE SEND(❌ FAILURE): JWT 토큰이 유효하지 않거나 누락되었습니다.")
+	void preSend_UnauthorizedException_fail() {
+		// GIVEN
+		String expectedValidToken = "Bearer expectedValidToken";
+		String expectedAccessToken = expectedValidToken.substring(7);
+
+		StompHeaderAccessor stompHeaderAccessor = StompHeaderAccessor.create(StompCommand.SEND);
+		stompHeaderAccessor.addNativeHeader(ACCESS_TOKEN_HEADER, expectedValidToken);
+		stompHeaderAccessor.setHeader(STOMP_COMMAND_HEADER, StompCommand.SEND);
+		stompHeaderAccessor.setLeaveMutable(true);
+
+		Message<byte[]> invalidMessage = MessageBuilder.createMessage(
+			new byte[0],
+			stompHeaderAccessor.getMessageHeaders());
+
+		when(jwtProviderService.isUsable(expectedAccessToken)).thenReturn(false);
+
+		// WHEN & THEN
+		assertThatThrownBy(() -> authChannelInterceptor.preSend(invalidMessage, messageChannel))
+			.isInstanceOf(UnauthorizedException.class)
+			.hasMessage("[❎ ERROR] 인증 토큰이 유효하지 않습니다. 다시 로그인해 주세요.");
+
+		verify(jwtProviderService).isUsable(expectedAccessToken);
+	}
+}

--- a/src/test/java/com/dart/api/infrastructure/websocket/WebSocketErrorHandlerTest.java
+++ b/src/test/java/com/dart/api/infrastructure/websocket/WebSocketErrorHandlerTest.java
@@ -1,0 +1,93 @@
+package com.dart.api.infrastructure.websocket;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+
+import com.dart.global.error.exception.UnauthorizedException;
+import com.dart.global.error.model.ErrorCode;
+
+import io.jsonwebtoken.JwtException;
+
+@ExtendWith(MockitoExtension.class)
+class WebSocketErrorHandlerTest {
+
+	@Mock
+	private Message<byte[]> clientMessage;
+
+	@InjectMocks
+	private WebSocketErrorHandler webSocketErrorHandler;
+
+	@Test
+	@DisplayName("HANDLE CLIENT MESSAGE PROCESSING ERROR(⭕️ SUCCESS): 만료된 JWT 토큰 예외를 처리하여 클라이언트 메시지 처리 오류를 성공적으로 핸들링했습니다.")
+	void handleClientMessageProcessingError_JwtException_success() {
+		// GIVEN
+		JwtException jwtException = new JwtException("[❎ ERROR] JWT TOKEN EXPIRED");
+		Throwable throwable = new Throwable(jwtException);
+
+		// WHEN
+		Message<byte[]> errorMessage = webSocketErrorHandler.handleClientMessageProcessingError(
+			clientMessage,
+			throwable);
+
+		// THEN
+		StompHeaderAccessor stompHeaderAccessor = StompHeaderAccessor.wrap(errorMessage);
+		assertEquals(StompCommand.ERROR, stompHeaderAccessor.getCommand());
+		assertEquals(
+			"[❎ ERROR] 인증 토큰이 만료되었습니다. 다시 로그인해 주세요.",
+			new String(errorMessage.getPayload(), StandardCharsets.UTF_8));
+	}
+
+	@Test
+	@DisplayName("HANDLE CLIENT MESSAGE PROCESSING ERROR(⭕️ SUCCESS): 인증되지 않은 예외를 처리하여 클라이언트 메시지 처리 오류를 성공적으로 핸들링했습니다.")
+	void handleClientMessageProcessingError_UnauthorizedException_success() {
+		// GIVEN
+		UnauthorizedException unauthorizedException = new UnauthorizedException(ErrorCode.FAIL_LOGIN_REQUIRED);
+		Throwable throwable = new Throwable(unauthorizedException);
+
+		// WHEN
+		Message<byte[]> errorMessage = webSocketErrorHandler.handleClientMessageProcessingError(
+			clientMessage,
+			throwable);
+
+		// THEN
+		StompHeaderAccessor accessor = StompHeaderAccessor.wrap(errorMessage);
+		assertEquals(StompCommand.ERROR, accessor.getCommand());
+		assertEquals(
+			"[❎ ERROR] 로그인이 필요한 기능입니다.",
+			new String(errorMessage.getPayload(), StandardCharsets.UTF_8));
+	}
+
+	@Test
+	@DisplayName("HANDLE CLIENT MESSAGE PROCESSING ERROR(⭕️ SUCCESS): 예상치 못한 예외를 처리하여 클라이언트 메시지 처리 오류를 성공적으로 핸들링했습니다.")
+	void handleClientMessageProcessingError_RuntimeException_success() {
+		// GIVEN
+		RuntimeException unexpectedException = new RuntimeException("[❎ ERROR] UNEXPECTED ERROR");
+		Throwable throwable = new Throwable(unexpectedException);
+
+		when(clientMessage.getHeaders()).thenReturn(new MessageHeaders(null));
+
+		// WHEN
+		Message<byte[]> errorMessage = webSocketErrorHandler.handleClientMessageProcessingError(
+			clientMessage,
+			throwable);
+
+		// THEN
+		assertNotNull(errorMessage, "ERROR MESSAGE SHOULD NOT BE NULL");
+
+		StompHeaderAccessor stompHeaderAccessor = StompHeaderAccessor.wrap(errorMessage);
+		assertEquals(StompCommand.ERROR, stompHeaderAccessor.getCommand());
+	}
+}

--- a/src/test/java/com/dart/support/GalleryFixture.java
+++ b/src/test/java/com/dart/support/GalleryFixture.java
@@ -79,6 +79,7 @@ public class GalleryFixture {
 			.startDate(LocalDateTime.now())
 			.endDate(LocalDateTime.now().plusDays(10))
 			.fee(1000)
+			.generatedCost(0)
 			.hashtags(List.of("happy", "good", "excellent"))
 			.informations(List.of(
 				new ImageInfoDto("image1.jpg", "Image 1"),


### PR DESCRIPTION
## 📋 CheckList
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. feat: 유저 조회 기능 구현)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

* close #250 

## 👩‍💻 공유 포인트 및 논의 사항
* 모든 알림 데이터를 포함하여 DB에 저장할 수 있는 알림 엔티티를 생성했습니다.
* 생성된 알림 모델을 DB에 저장할 수 있도록 JPA 저장소를 생성했습니다.
