### PR TITLE
feat: 이달의 쿠폰 발행을 구현

### DIFF
--- a/src/main/java/com/dart/api/application/coupon/GeneralCouponManageService.java
+++ b/src/main/java/com/dart/api/application/coupon/GeneralCouponManageService.java
@@ -15,7 +15,7 @@ import com.dart.api.domain.coupon.repository.GeneralCouponWalletRepository;
 import com.dart.api.domain.member.entity.Member;
 import com.dart.api.domain.member.repository.MemberRepository;
 import com.dart.api.dto.coupon.request.GeneralCouponPublishDto;
-import com.dart.global.error.exception.BadRequestException;
+import com.dart.global.error.exception.ConflictException;
 import com.dart.global.error.exception.NotFoundException;
 import com.dart.global.error.model.ErrorCode;
 
@@ -39,7 +39,7 @@ public class GeneralCouponManageService {
 
 	public void publish(GeneralCouponPublishDto dto, AuthUser authUser) {
 		final GeneralCoupon generalCoupon = generalCouponRepository.findById(dto.generalCouponId())
-			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_MEMBER_NOT_FOUND));
+			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_COUPON_NOT_FOUND));
 		final Member member = memberRepository.findByEmail(authUser.email())
 			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_MEMBER_NOT_FOUND));
 
@@ -51,7 +51,7 @@ public class GeneralCouponManageService {
 
 	private void validateAlreadyCoupon(GeneralCoupon generalCoupon, Member member) {
 		if (generalCouponWalletRepository.existsByGeneralCouponAndMember(generalCoupon, member)) {
-			throw new BadRequestException(ErrorCode.FAIL_MEMBER_NOT_FOUND);
+			throw new ConflictException(ErrorCode.FAIL_COUPON_CONFLICT);
 		}
 	}
 }

--- a/src/main/java/com/dart/api/application/coupon/GeneralCouponManageService.java
+++ b/src/main/java/com/dart/api/application/coupon/GeneralCouponManageService.java
@@ -1,0 +1,45 @@
+package com.dart.api.application.coupon;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.dart.api.domain.auth.entity.AuthUser;
+import com.dart.api.domain.coupon.entity.GeneralCoupon;
+import com.dart.api.domain.coupon.entity.GeneralCouponWallet;
+import com.dart.api.domain.coupon.repository.GeneralCouponRepository;
+import com.dart.api.domain.coupon.repository.GeneralCouponWalletRepository;
+import com.dart.api.domain.member.entity.Member;
+import com.dart.api.domain.member.repository.MemberRepository;
+import com.dart.api.dto.coupon.request.GeneralCouponPublishDto;
+import com.dart.global.error.exception.BadRequestException;
+import com.dart.global.error.exception.NotFoundException;
+import com.dart.global.error.model.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class GeneralCouponManageService {
+	private final GeneralCouponRepository generalCouponRepository;
+	private final GeneralCouponWalletRepository generalCouponWalletRepository;
+	private final MemberRepository memberRepository;
+
+	public void publish(GeneralCouponPublishDto dto, AuthUser authUser) {
+		final GeneralCoupon generalCoupon = generalCouponRepository.findById(dto.generalCouponId())
+			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_MEMBER_NOT_FOUND));
+		final Member member = memberRepository.findByEmail(authUser.email())
+			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_MEMBER_NOT_FOUND));
+
+		validateAlreadyCoupon(generalCoupon, member);
+
+		final GeneralCouponWallet generalCouponWallet = GeneralCouponWallet.create(generalCoupon, member);
+		generalCouponWalletRepository.save(generalCouponWallet);
+	}
+
+	private void validateAlreadyCoupon(GeneralCoupon generalCoupon, Member member) {
+		if (generalCouponWalletRepository.existsByGeneralCouponAndMember(generalCoupon, member)) {
+			throw new BadRequestException(ErrorCode.FAIL_MEMBER_NOT_FOUND);
+		}
+	}
+}

--- a/src/main/java/com/dart/api/application/coupon/GeneralCouponManageService.java
+++ b/src/main/java/com/dart/api/application/coupon/GeneralCouponManageService.java
@@ -1,9 +1,13 @@
 package com.dart.api.application.coupon;
 
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.dart.api.domain.auth.entity.AuthUser;
+import com.dart.api.domain.coupon.entity.CouponEventType;
 import com.dart.api.domain.coupon.entity.GeneralCoupon;
 import com.dart.api.domain.coupon.entity.GeneralCouponWallet;
 import com.dart.api.domain.coupon.repository.GeneralCouponRepository;
@@ -24,6 +28,14 @@ public class GeneralCouponManageService {
 	private final GeneralCouponRepository generalCouponRepository;
 	private final GeneralCouponWalletRepository generalCouponWalletRepository;
 	private final MemberRepository memberRepository;
+
+	@Scheduled(cron = "0 0 0 1 * ?")
+	public void reset() {
+		final List<GeneralCouponWallet> generalCouponWallets = generalCouponWalletRepository
+			.findByGeneralCoupon_CouponEventType(CouponEventType.MONTHLY_COUPON);
+
+		generalCouponWalletRepository.deleteAll(generalCouponWallets);
+	}
 
 	public void publish(GeneralCouponPublishDto dto, AuthUser authUser) {
 		final GeneralCoupon generalCoupon = generalCouponRepository.findById(dto.generalCouponId())

--- a/src/main/java/com/dart/api/application/coupon/GeneralCouponManageService.java
+++ b/src/main/java/com/dart/api/application/coupon/GeneralCouponManageService.java
@@ -1,5 +1,7 @@
 package com.dart.api.application.coupon;
 
+import static com.dart.global.common.util.CouponConstant.*;
+
 import java.util.List;
 
 import org.springframework.scheduling.annotation.Scheduled;
@@ -29,7 +31,7 @@ public class GeneralCouponManageService {
 	private final GeneralCouponWalletRepository generalCouponWalletRepository;
 	private final MemberRepository memberRepository;
 
-	@Scheduled(cron = "0 0 0 1 * ?")
+	@Scheduled(cron = EVERY_MONTH_FIRST_DAY)
 	public void reset() {
 		final List<GeneralCouponWallet> generalCouponWallets = generalCouponWalletRepository
 			.findByGeneralCoupon_CouponEventType(CouponEventType.MONTHLY_COUPON);

--- a/src/main/java/com/dart/api/application/coupon/PriorityCouponManageService.java
+++ b/src/main/java/com/dart/api/application/coupon/PriorityCouponManageService.java
@@ -19,7 +19,7 @@ import com.dart.api.domain.coupon.repository.PriorityCouponRedisRepository;
 import com.dart.api.domain.coupon.repository.PriorityCouponWalletRepository;
 import com.dart.api.domain.member.entity.Member;
 import com.dart.api.domain.member.repository.MemberRepository;
-import com.dart.api.dto.prioritycoupon.request.PriorityCouponPublishDto;
+import com.dart.api.dto.coupon.request.PriorityCouponPublishDto;
 import com.dart.global.error.exception.BadRequestException;
 import com.dart.global.error.exception.ConflictException;
 import com.dart.global.error.exception.NotFoundException;

--- a/src/main/java/com/dart/api/domain/coupon/entity/CouponEventType.java
+++ b/src/main/java/com/dart/api/domain/coupon/entity/CouponEventType.java
@@ -1,0 +1,23 @@
+package com.dart.api.domain.coupon.entity;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CouponEventType {
+	MONTHLY_COUPON("이달의쿠폰"),
+	WELCOME_COUPON("웰컴쿠폰"),
+	LAUNCHING_COUPON("런칭기념쿠폰");
+
+	private final String name;
+
+	private static final Map<String, CouponEventType> namesMap = Collections.unmodifiableMap(Stream.of(values())
+		.collect(Collectors.toMap(CouponEventType::getName, Function.identity())));
+}

--- a/src/main/java/com/dart/api/domain/coupon/entity/GeneralCoupon.java
+++ b/src/main/java/com/dart/api/domain/coupon/entity/GeneralCoupon.java
@@ -1,0 +1,31 @@
+package com.dart.api.domain.coupon.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "tbl_general_coupon")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GeneralCoupon {
+	@Id
+	@Column(name = "id")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String title;
+
+	private CouponType couponType;
+
+	public GeneralCoupon(String title, CouponType couponType) {
+		this.title = title;
+		this.couponType = couponType;
+	}
+}

--- a/src/main/java/com/dart/api/domain/coupon/entity/GeneralCoupon.java
+++ b/src/main/java/com/dart/api/domain/coupon/entity/GeneralCoupon.java
@@ -29,8 +29,13 @@ public class GeneralCoupon {
 	@Enumerated(EnumType.STRING)
 	private CouponType couponType;
 
-	public GeneralCoupon(String title, CouponType couponType) {
+	@Column(name = "coupon_event_type")
+	@Enumerated(EnumType.STRING)
+	private CouponEventType couponEventType;
+
+	public GeneralCoupon(String title, CouponType couponType, CouponEventType couponEventType) {
 		this.title = title;
 		this.couponType = couponType;
+		this.couponEventType = couponEventType;
 	}
 }

--- a/src/main/java/com/dart/api/domain/coupon/entity/GeneralCoupon.java
+++ b/src/main/java/com/dart/api/domain/coupon/entity/GeneralCoupon.java
@@ -2,6 +2,8 @@ package com.dart.api.domain.coupon.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -20,8 +22,11 @@ public class GeneralCoupon {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
+	@Column(name = "title", nullable = false)
 	private String title;
 
+	@Column(name = "coupon_type")
+	@Enumerated(EnumType.STRING)
 	private CouponType couponType;
 
 	public GeneralCoupon(String title, CouponType couponType) {

--- a/src/main/java/com/dart/api/domain/coupon/entity/GeneralCouponWallet.java
+++ b/src/main/java/com/dart/api/domain/coupon/entity/GeneralCouponWallet.java
@@ -33,8 +33,16 @@ public class GeneralCouponWallet {
 	@JoinColumn(name = "member_id")
 	private Member member;
 
-	public GeneralCouponWallet(GeneralCoupon generalCoupon, Member member) {
+	@Column(name = "is_used")
+	private boolean isUsed;
+
+	private GeneralCouponWallet(GeneralCoupon generalCoupon, Member member) {
 		this.generalCoupon = generalCoupon;
 		this.member = member;
+		this.isUsed = false;
+	}
+
+	public static GeneralCouponWallet create(GeneralCoupon generalCoupon, Member member) {
+		return new GeneralCouponWallet(generalCoupon, member);
 	}
 }

--- a/src/main/java/com/dart/api/domain/coupon/entity/GeneralCouponWallet.java
+++ b/src/main/java/com/dart/api/domain/coupon/entity/GeneralCouponWallet.java
@@ -1,0 +1,40 @@
+package com.dart.api.domain.coupon.entity;
+
+import com.dart.api.domain.member.entity.Member;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "tbl_general_coupon_wallet")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GeneralCouponWallet {
+	@Id
+	@Column(name = "id")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "general_coupon_id")
+	private GeneralCoupon generalCoupon;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
+
+	public GeneralCouponWallet(GeneralCoupon generalCoupon, Member member) {
+		this.generalCoupon = generalCoupon;
+		this.member = member;
+	}
+}

--- a/src/main/java/com/dart/api/domain/coupon/repository/GeneralCouponRepository.java
+++ b/src/main/java/com/dart/api/domain/coupon/repository/GeneralCouponRepository.java
@@ -1,0 +1,10 @@
+package com.dart.api.domain.coupon.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.dart.api.domain.coupon.entity.GeneralCouponWallet;
+
+@Repository
+public interface GeneralCouponRepository extends JpaRepository<GeneralCouponWallet, Long> {
+}

--- a/src/main/java/com/dart/api/domain/coupon/repository/GeneralCouponRepository.java
+++ b/src/main/java/com/dart/api/domain/coupon/repository/GeneralCouponRepository.java
@@ -3,8 +3,8 @@ package com.dart.api.domain.coupon.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import com.dart.api.domain.coupon.entity.GeneralCouponWallet;
+import com.dart.api.domain.coupon.entity.GeneralCoupon;
 
 @Repository
-public interface GeneralCouponRepository extends JpaRepository<GeneralCouponWallet, Long> {
+public interface GeneralCouponRepository extends JpaRepository<GeneralCoupon, Long> {
 }

--- a/src/main/java/com/dart/api/domain/coupon/repository/GeneralCouponWalletRepository.java
+++ b/src/main/java/com/dart/api/domain/coupon/repository/GeneralCouponWalletRepository.java
@@ -1,0 +1,10 @@
+package com.dart.api.domain.coupon.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.dart.api.domain.coupon.entity.GeneralCouponWallet;
+
+@Repository
+public interface GeneralCouponWalletRepository extends JpaRepository<GeneralCouponWallet, Long> {
+}

--- a/src/main/java/com/dart/api/domain/coupon/repository/GeneralCouponWalletRepository.java
+++ b/src/main/java/com/dart/api/domain/coupon/repository/GeneralCouponWalletRepository.java
@@ -1,10 +1,18 @@
 package com.dart.api.domain.coupon.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import com.dart.api.domain.coupon.entity.CouponEventType;
+import com.dart.api.domain.coupon.entity.GeneralCoupon;
 import com.dart.api.domain.coupon.entity.GeneralCouponWallet;
+import com.dart.api.domain.member.entity.Member;
 
 @Repository
 public interface GeneralCouponWalletRepository extends JpaRepository<GeneralCouponWallet, Long> {
+	boolean existsByGeneralCouponAndMember(GeneralCoupon generalCoupon, Member member);
+
+	List<GeneralCouponWallet> findByGeneralCoupon_CouponEventType(CouponEventType couponEventType);
 }

--- a/src/main/java/com/dart/api/dto/coupon/request/GeneralCouponPublishDto.java
+++ b/src/main/java/com/dart/api/dto/coupon/request/GeneralCouponPublishDto.java
@@ -1,0 +1,9 @@
+package com.dart.api.dto.coupon.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record GeneralCouponPublishDto(
+	@NotNull
+	Long generalCouponId
+) {
+}

--- a/src/main/java/com/dart/api/dto/coupon/request/PriorityCouponPublishDto.java
+++ b/src/main/java/com/dart/api/dto/coupon/request/PriorityCouponPublishDto.java
@@ -1,4 +1,4 @@
-package com.dart.api.dto.prioritycoupon.request;
+package com.dart.api.dto.coupon.request;
 
 import jakarta.validation.constraints.NotNull;
 

--- a/src/main/java/com/dart/api/presentation/CouponController.java
+++ b/src/main/java/com/dart/api/presentation/CouponController.java
@@ -5,9 +5,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.dart.api.application.coupon.GeneralCouponManageService;
 import com.dart.api.application.coupon.PriorityCouponManageService;
 import com.dart.api.domain.auth.entity.AuthUser;
-import com.dart.api.dto.prioritycoupon.request.PriorityCouponPublishDto;
+import com.dart.api.dto.coupon.request.GeneralCouponPublishDto;
+import com.dart.api.dto.coupon.request.PriorityCouponPublishDto;
 import com.dart.global.auth.annotation.Auth;
 
 import lombok.RequiredArgsConstructor;
@@ -16,10 +18,16 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/events")
 @RequiredArgsConstructor
 public class PriorityCouponController {
-	private final PriorityCouponManageService couponManageService;
+	private final PriorityCouponManageService priorityCouponManageService;
+	private final GeneralCouponManageService generalCouponManageService;
 
 	@PostMapping("/priority-coupon")
 	public void registerQueue(@RequestBody PriorityCouponPublishDto dto, @Auth AuthUser authUser) {
-		couponManageService.registerQueue(dto, authUser.email());
+		priorityCouponManageService.registerQueue(dto, authUser.email());
+	}
+
+	@PostMapping("/general-coupon")
+	public void publish(@RequestBody GeneralCouponPublishDto dto, @Auth AuthUser authUser) {
+		generalCouponManageService.publish(dto, authUser);
 	}
 }

--- a/src/main/java/com/dart/api/presentation/CouponController.java
+++ b/src/main/java/com/dart/api/presentation/CouponController.java
@@ -17,7 +17,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/api/events")
 @RequiredArgsConstructor
-public class PriorityCouponController {
+public class CouponController {
 	private final PriorityCouponManageService priorityCouponManageService;
 	private final GeneralCouponManageService generalCouponManageService;
 

--- a/src/main/java/com/dart/global/common/util/CouponConstant.java
+++ b/src/main/java/com/dart/global/common/util/CouponConstant.java
@@ -7,4 +7,6 @@ import lombok.NoArgsConstructor;
 public class CouponConstant {
 	public static final int ONE_SECOND = 1000;
 	public static final int TEN_PERSON = 10;
+
+	public static final String EVERY_MONTH_FIRST_DAY = "0 0 0 1 * ?";
 }

--- a/src/test/java/com/dart/api/application/coupon/CouponManageServiceTest.java
+++ b/src/test/java/com/dart/api/application/coupon/CouponManageServiceTest.java
@@ -22,7 +22,7 @@ import com.dart.api.domain.coupon.repository.PriorityCouponRedisRepository;
 import com.dart.api.domain.coupon.repository.PriorityCouponWalletRepository;
 import com.dart.api.domain.member.entity.Member;
 import com.dart.api.domain.member.repository.MemberRepository;
-import com.dart.api.dto.prioritycoupon.request.PriorityCouponPublishDto;
+import com.dart.api.dto.coupon.request.PriorityCouponPublishDto;
 import com.dart.global.error.exception.BadRequestException;
 import com.dart.global.error.exception.ConflictException;
 import com.dart.support.CouponFixture;

--- a/src/test/java/com/dart/api/application/coupon/GeneralCouponManageServiceTest.java
+++ b/src/test/java/com/dart/api/application/coupon/GeneralCouponManageServiceTest.java
@@ -1,0 +1,78 @@
+package com.dart.api.application.coupon;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.dart.api.domain.auth.entity.AuthUser;
+import com.dart.api.domain.coupon.entity.GeneralCoupon;
+import com.dart.api.domain.coupon.entity.GeneralCouponWallet;
+import com.dart.api.domain.coupon.repository.GeneralCouponRepository;
+import com.dart.api.domain.coupon.repository.GeneralCouponWalletRepository;
+import com.dart.api.domain.member.entity.Member;
+import com.dart.api.domain.member.repository.MemberRepository;
+import com.dart.api.dto.coupon.request.GeneralCouponPublishDto;
+import com.dart.global.error.exception.ConflictException;
+import com.dart.support.CouponFixture;
+import com.dart.support.MemberFixture;
+
+@ExtendWith({MockitoExtension.class})
+class GeneralCouponManageServiceTest {
+	@Mock
+	private MemberRepository memberRepository;
+
+	@Mock
+	private GeneralCouponRepository generalCouponRepository;
+
+	@Mock
+	private GeneralCouponWalletRepository generalCouponWalletRepository;
+
+	@InjectMocks
+	private GeneralCouponManageService generalCouponManageService;
+
+	@Test
+	@DisplayName("일반 쿠폰을 성공적으로 발급한다. - Void")
+	void publish_Success() {
+		// GIVEN
+		GeneralCoupon generalCoupon = CouponFixture.createGeneralCoupon();
+		Member member = MemberFixture.createMemberEntity();
+		AuthUser authUser = MemberFixture.createAuthUserEntity();
+		GeneralCouponPublishDto dto = new GeneralCouponPublishDto(generalCoupon.getId());
+
+		given(generalCouponRepository.findById(dto.generalCouponId())).willReturn(Optional.of(generalCoupon));
+		given(memberRepository.findByEmail(authUser.email())).willReturn(Optional.ofNullable(member));
+		given(generalCouponWalletRepository.existsByGeneralCouponAndMember(generalCoupon, member)).willReturn(false);
+
+		// WHEN
+		generalCouponManageService.publish(dto, authUser);
+
+		// THEN
+		verify(generalCouponWalletRepository, times(1)).save(any(GeneralCouponWallet.class));
+	}
+
+	@Test
+	@DisplayName("이미 해당 쿠폰은 발급받은 쿠폰이다. - ConflictException")
+	void publish_No_ConflictException() {
+		// GIVEN
+		GeneralCoupon generalCoupon = CouponFixture.createGeneralCoupon();
+		Member member = MemberFixture.createMemberEntity();
+		AuthUser authUser = MemberFixture.createAuthUserEntity();
+		GeneralCouponPublishDto dto = new GeneralCouponPublishDto(generalCoupon.getId());
+
+		given(generalCouponRepository.findById(dto.generalCouponId())).willReturn(Optional.of(generalCoupon));
+		given(memberRepository.findByEmail(authUser.email())).willReturn(Optional.ofNullable(member));
+		given(generalCouponWalletRepository.existsByGeneralCouponAndMember(generalCoupon, member)).willReturn(true);
+
+		// WHEN & THEN
+		assertThatThrownBy(() -> generalCouponManageService.publish(dto, authUser))
+			.isInstanceOf(ConflictException.class);
+	}
+}

--- a/src/test/java/com/dart/api/application/coupon/GeneralCouponManageServiceTest.java
+++ b/src/test/java/com/dart/api/application/coupon/GeneralCouponManageServiceTest.java
@@ -3,16 +3,20 @@ package com.dart.api.application.coupon;
 import static org.assertj.core.api.AssertionsForClassTypes.*;
 import static org.mockito.BDDMockito.*;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.dart.api.domain.auth.entity.AuthUser;
+import com.dart.api.domain.coupon.entity.CouponEventType;
 import com.dart.api.domain.coupon.entity.GeneralCoupon;
 import com.dart.api.domain.coupon.entity.GeneralCouponWallet;
 import com.dart.api.domain.coupon.repository.GeneralCouponRepository;
@@ -37,6 +41,21 @@ class GeneralCouponManageServiceTest {
 
 	@InjectMocks
 	private GeneralCouponManageService generalCouponManageService;
+
+	@DisplayName("5명 사용자의 쿠폰을 초기화한다.")
+	@MethodSource("com.dart.support.CouponFixture#provideGeneralCouponWallet_total5")
+	@ParameterizedTest
+	void reset_all_success(List<GeneralCouponWallet> values) {
+		// GIVEN
+		given(generalCouponWalletRepository.findByGeneralCoupon_CouponEventType(any(CouponEventType.class)))
+			.willReturn(values);
+
+		// WHEN
+		generalCouponManageService.reset();
+
+		// THEN
+		verify(generalCouponWalletRepository, times(1)).deleteAll(values);
+	}
 
 	@Test
 	@DisplayName("일반 쿠폰을 성공적으로 발급한다. - Void")

--- a/src/test/java/com/dart/api/application/coupon/PriorityCouponManageServiceTest.java
+++ b/src/test/java/com/dart/api/application/coupon/PriorityCouponManageServiceTest.java
@@ -29,7 +29,7 @@ import com.dart.support.CouponFixture;
 import com.dart.support.MemberFixture;
 
 @ExtendWith({MockitoExtension.class})
-class CouponManageServiceTest {
+class PriorityCouponManageServiceTest {
 	@Mock
 	private PriorityCouponCacheService priorityCouponCacheService;
 

--- a/src/test/java/com/dart/api/application/coupon/PriorityCouponManageServiceTest.java
+++ b/src/test/java/com/dart/api/application/coupon/PriorityCouponManageServiceTest.java
@@ -50,7 +50,7 @@ class PriorityCouponManageServiceTest {
 	@ParameterizedTest
 	void publish_all_success(Set<String> values) {
 		// Given
-		PriorityCoupon priorityCoupon = CouponFixture.create();
+		PriorityCoupon priorityCoupon = CouponFixture.createPriorityCoupon();
 		given(priorityCouponCacheService.getByStartAt(any(LocalDate.class))).willReturn(Optional.of(priorityCoupon));
 		given(priorityCouponRedisRepository.getCount(eq(priorityCoupon.getId()))).willReturn(
 			priorityCoupon.getStock() - 1);
@@ -91,7 +91,7 @@ class PriorityCouponManageServiceTest {
 	@DisplayName("쿠폰 발급 요청을 성공적으로 대기열 큐에 등록한다. - Void")
 	void registerQueue_Success() {
 		// GIVEN
-		PriorityCoupon priorityCoupon = CouponFixture.create();
+		PriorityCoupon priorityCoupon = CouponFixture.createPriorityCoupon();
 		String testEmail = "test@example.com";
 		PriorityCouponPublishDto dto = new PriorityCouponPublishDto(priorityCoupon.getId());
 
@@ -113,7 +113,7 @@ class PriorityCouponManageServiceTest {
 	@DisplayName("이미 해당 쿠폰은 발급받은 쿠폰이다. - ConflictException")
 	void registerQueue_No_ConflictException() {
 		// GIVEN
-		PriorityCoupon priorityCoupon = CouponFixture.create();
+		PriorityCoupon priorityCoupon = CouponFixture.createPriorityCoupon();
 		String testEmail = "test@example.com";
 		PriorityCouponPublishDto dto = new PriorityCouponPublishDto(priorityCoupon.getId());
 
@@ -131,7 +131,7 @@ class PriorityCouponManageServiceTest {
 	@DisplayName("해당 쿠폰은 재고가 마감된 쿠폰이다. - BadRequestException")
 	void registerQueue_No_BadRequestException() {
 		// GIVEN
-		PriorityCoupon priorityCoupon = CouponFixture.create();
+		PriorityCoupon priorityCoupon = CouponFixture.createPriorityCoupon();
 		String testEmail = "test@example.com";
 		PriorityCouponPublishDto dto = new PriorityCouponPublishDto(priorityCoupon.getId());
 

--- a/src/test/java/com/dart/support/CouponFixture.java
+++ b/src/test/java/com/dart/support/CouponFixture.java
@@ -1,7 +1,10 @@
 package com.dart.support;
 
+import static com.dart.support.MemberFixture.*;
+
 import java.time.LocalDate;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -10,6 +13,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import com.dart.api.domain.coupon.entity.CouponEventType;
 import com.dart.api.domain.coupon.entity.CouponType;
 import com.dart.api.domain.coupon.entity.GeneralCoupon;
+import com.dart.api.domain.coupon.entity.GeneralCouponWallet;
 import com.dart.api.domain.coupon.entity.PriorityCoupon;
 
 public class CouponFixture {
@@ -41,5 +45,17 @@ public class CouponFixture {
 		values.add("test10@naver.com");
 
 		return Stream.of(Arguments.of(values));
+	}
+
+	public static Stream<Arguments> provideGeneralCouponWallet_total5() {
+		return Stream.of(Arguments.of(
+			List.of(
+				GeneralCouponWallet.create(createGeneralCoupon(), createMemberEntity()),
+				GeneralCouponWallet.create(createGeneralCoupon(), createMemberEntity()),
+				GeneralCouponWallet.create(createGeneralCoupon(), createMemberEntity()),
+				GeneralCouponWallet.create(createGeneralCoupon(), createMemberEntity()),
+				GeneralCouponWallet.create(createGeneralCoupon(), createMemberEntity())
+			))
+		);
 	}
 }

--- a/src/test/java/com/dart/support/CouponFixture.java
+++ b/src/test/java/com/dart/support/CouponFixture.java
@@ -7,11 +7,13 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.params.provider.Arguments;
 
+import com.dart.api.domain.coupon.entity.CouponEventType;
 import com.dart.api.domain.coupon.entity.CouponType;
+import com.dart.api.domain.coupon.entity.GeneralCoupon;
 import com.dart.api.domain.coupon.entity.PriorityCoupon;
 
 public class CouponFixture {
-	public static PriorityCoupon create() {
+	public static PriorityCoupon createPriorityCoupon() {
 		return PriorityCoupon.builder()
 			.stock(100)
 			.title("오픈기념선착순")
@@ -19,6 +21,10 @@ public class CouponFixture {
 			.endedAt(LocalDate.now().plusDays(1))
 			.couponType(CouponType.TEN_PERCENT)
 			.build();
+	}
+
+	public static GeneralCoupon createGeneralCoupon() {
+		return new GeneralCoupon("10%할인", CouponType.TEN_PERCENT, CouponEventType.MONTHLY_COUPON);
 	}
 
 	public static Stream<Arguments> provideValues_String() {

--- a/src/test/java/com/dart/support/GalleryFixture.java
+++ b/src/test/java/com/dart/support/GalleryFixture.java
@@ -79,6 +79,7 @@ public class GalleryFixture {
 			.startDate(LocalDateTime.now())
 			.endDate(LocalDateTime.now().plusDays(10))
 			.fee(1000)
+			.generatedCost(0)
 			.hashtags(List.of("happy", "good", "excellent"))
 			.informations(List.of(
 				new ImageInfoDto("image1.jpg", "Image 1"),


### PR DESCRIPTION
## 📋 CheckList
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. feat: 유저 조회 기능 구현)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

* close #246 

## 👩‍💻 공유 포인트 및 논의 사항
* <요구사항>
* 이달의 쿠폰은 매달 초기화 되어야합니다.
* 사용자가 쿠폰을 사용하든 안 하든 매달 다시 받을 수 있어야 합니다.
* 한 달이 지나면 쿠폰이 있더라도 삭제되고 다시 발급 요청을 해야합니다.
* 요구사항에 맞게, 사용자가 이번 달 쿠폰 사용 여부를 위해 isUsed 필드를 추가해주었습니다.
* 또한 일반 쿠폰 지갑의 쿠폰 타입이 이달의 쿠폰이라면, 매월 1일 00시 00분에 삭제해주는 것으로 구현했습니다. 
