### PR TITLE
feat: 재전시 요청 10회 초과 시 알림 이벤트 전송 로직 구현

### DIFF
--- a/src/main/java/com/dart/api/application/gallery/GalleryService.java
+++ b/src/main/java/com/dart/api/application/gallery/GalleryService.java
@@ -1,6 +1,7 @@
 package com.dart.api.application.gallery;
 
 import static com.dart.global.common.util.GlobalConstant.*;
+import static com.dart.global.common.util.SSEConstant.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -15,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.dart.api.application.chat.ChatRoomService;
+import com.dart.api.application.notification.ExhibitionNotificationService;
 import com.dart.api.domain.auth.entity.AuthUser;
 import com.dart.api.domain.chat.entity.ChatRoom;
 import com.dart.api.domain.chat.repository.ChatRoomRepository;
@@ -64,6 +66,7 @@ public class GalleryService {
 	private final PaymentRedisRepository paymentRedisRepository;
 	private final ChatRoomService chatRoomService;
 	private final ChatRoomRepository chatRoomRepository;
+	private final ExhibitionNotificationService exhibitionNotificationService;
 
 	public GalleryReadIdDto createGallery(CreateGalleryDto createGalleryDto, MultipartFile thumbnail,
 		List<MultipartFile> imageFiles, AuthUser authUser) {
@@ -188,6 +191,17 @@ public class GalleryService {
 		imageService.deleteThumbnail(gallery);
 		hashtagService.deleteHashtagsByGallery(gallery);
 		deleteGallery(gallery);
+	}
+
+	public void updateReExhibitionRequestCount(Long galleryId) {
+		final Gallery gallery = galleryRepository.findById(galleryId)
+				.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_GALLERY_NOT_FOUND));
+		gallery.incrementReExhibitionRequestCount();
+
+		if (gallery.getReExhibitionRequestCount() >= REEXHIBITION_REQUEST_COUNT) {
+			exhibitionNotificationService.sendReExhibitionRequestNotification(galleryId);
+			gallery.resetReExhibitionRequestCount();
+		}
 	}
 
 	private Member findMemberByEmail(String email) {

--- a/src/main/java/com/dart/api/application/notification/CouponNotificationService.java
+++ b/src/main/java/com/dart/api/application/notification/CouponNotificationService.java
@@ -29,8 +29,7 @@ public class CouponNotificationService {
 	private final SSESessionRepository sseSessionRepository;
 	private final PriorityCouponRepository priorityCouponRepository;
 
-	//@Scheduled(cron = DAILY_AT_MIDNIGHT)
-	@Scheduled(fixedRate = 10000)
+	@Scheduled(cron = DAILY_AT_MIDNIGHT)
 	@Transactional
 	public void sendCouponPublishNotification() {
 		List<PriorityCoupon> priorityCouponList = getTodayCoupons();

--- a/src/main/java/com/dart/api/application/notification/ExhibitionNotificationService.java
+++ b/src/main/java/com/dart/api/application/notification/ExhibitionNotificationService.java
@@ -1,0 +1,67 @@
+package com.dart.api.application.notification;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.dart.api.domain.gallery.entity.Gallery;
+import com.dart.api.domain.gallery.repository.GalleryRepository;
+import com.dart.api.domain.notification.entity.Notification;
+import com.dart.api.domain.notification.entity.NotificationType;
+import com.dart.api.domain.notification.repository.NotificationRepository;
+import com.dart.api.domain.notification.repository.SSESessionRepository;
+import com.dart.global.error.exception.NotFoundException;
+import com.dart.global.error.model.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ExhibitionNotificationService {
+
+	private final NotificationRepository notificationRepository;
+	private final SSESessionRepository sseSessionRepository;
+	private final GalleryRepository galleryRepository;
+
+	@Transactional
+	public void sendReExhibitionRequestNotification(Long galleryId) {
+		final Gallery gallery = getGalleryById(galleryId);
+		final String message =
+			"EXHIBITION '" + gallery.getTitle() + "' HAS RECEIVED MORE THAN 10 RE-EXHIBITION REQUESTS. "
+				+ "PLEASE CONSIDER RE-EXHIBITION";
+
+		sendReExhibitionRequestEventNotification(gallery, message);
+	}
+
+	private Gallery getGalleryById(Long galleryId) {
+		return galleryRepository.findById(galleryId)
+			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_GALLERY_NOT_FOUND));
+	}
+
+	private void sendReExhibitionRequestEventNotification(Gallery gallery, String exhibitionDetail) {
+		sseSessionRepository.sendEvent(
+			gallery.getMember().getId(),
+			exhibitionDetail,
+			NotificationType.REEXHIBITION_REQUEST.getName()
+		);
+		log.info("[✅ LOGGER] REEXHIBITION REQUEST NOTIFICATION SENT TO AUTHOR ID: {}", gallery.getMember().getId());
+
+		saveCommonNotification(exhibitionDetail, gallery);
+	}
+
+	private void saveCommonNotification(String message, Gallery gallery) {
+		if (notificationRepository.existsByNotificationType(NotificationType.REEXHIBITION_REQUEST)) {
+			log.info("[✅ LOGGER] DUPLICATE REEXHIBITION REQUEST NOTIFICATION DETECTED: {}", message);
+			return;
+		}
+
+		final Notification notification = Notification.createNotification(
+			message,
+			NotificationType.REEXHIBITION_REQUEST,
+			"https://dartgallery.site/api/galleries/" + gallery.getId()
+		);
+		notificationRepository.save(notification);
+	}
+}

--- a/src/main/java/com/dart/api/domain/gallery/entity/Gallery.java
+++ b/src/main/java/com/dart/api/domain/gallery/entity/Gallery.java
@@ -65,6 +65,9 @@ public class Gallery extends BaseTimeEntity {
 	@Column(name = "is_paid")
 	private boolean isPaid;
 
+	@Column(name = "re_exhibition_request_count", nullable = false)
+	private int reExhibitionRequestCount;
+
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "meber_id")
 	private Member member;
@@ -110,5 +113,13 @@ public class Gallery extends BaseTimeEntity {
 
 	public GalleryReadIdDto toReadIdDto() {
 		return new GalleryReadIdDto(this.id);
+	}
+
+	public void incrementReExhibitionRequestCount() {
+		this.reExhibitionRequestCount++;
+	}
+
+	public void resetReExhibitionRequestCount() {
+		this.reExhibitionRequestCount = 0;
 	}
 }

--- a/src/main/java/com/dart/api/domain/notification/entity/NotificationType.java
+++ b/src/main/java/com/dart/api/domain/notification/entity/NotificationType.java
@@ -1,6 +1,15 @@
 package com.dart.api.domain.notification.entity;
 
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public enum NotificationType {
 
-	COUPON_START
+	COUPON_START("쿠폰 발행"),
+	REEXHIBITION_REQUEST("재전시 요청");
+
+	private final String name;
 }

--- a/src/main/java/com/dart/api/presentation/GalleryController.java
+++ b/src/main/java/com/dart/api/presentation/GalleryController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -76,5 +77,11 @@ public class GalleryController {
 	public ResponseEntity<GalleryInfoDto> getGalleryInfo(@RequestParam("gallery-id") Long galleryId,
 		@Auth(required = false) AuthUser authUser) {
 		return ResponseEntity.ok(galleryService.getGalleryInfo(galleryId, authUser));
+	}
+
+	@PutMapping("/reexhibition")
+	public ResponseEntity<String> updateReExhibitionRequestCount(@RequestParam("gallery-id") Long galleryId) {
+		galleryService.updateReExhibitionRequestCount(galleryId);
+		return ResponseEntity.ok("OK");
 	}
 }

--- a/src/main/java/com/dart/global/common/util/SSEConstant.java
+++ b/src/main/java/com/dart/global/common/util/SSEConstant.java
@@ -11,4 +11,5 @@ public class SSEConstant {
 	public static final long SSE_DEFAULT_TIMEOUT = 60 * 60 * 1000L;
 	public static final String SSE_EMITTER_EVENT_NAME = "SSE";
 	public static final String DAILY_AT_MIDNIGHT = "0 0 0 * * ?";
+	public static final int REEXHIBITION_REQUEST_COUNT = 10;
 }


### PR DESCRIPTION
## 📋 CheckList
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. feat: 유저 조회 기능 구현)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

* close #259 

## 👩‍💻 공유 포인트 및 논의 사항
* 재전시 요청 10회 초과 시 작가에게 알림 이벤트가 전송되도록 구현했습니다.
* 전시회 모델에 재전송 요청 횟수를 추가하여 재전시 요청 횟수를 증가시키는 로직 및 엔드포인트를 설정했습니다.
