### PR TITLE
refactor: 웹소켓 인터셉터 및 이벤트 리스너 로직 수정

### DIFF
--- a/src/main/java/com/dart/api/infrastructure/websocket/WebSocketEventListener.java
+++ b/src/main/java/com/dart/api/infrastructure/websocket/WebSocketEventListener.java
@@ -54,7 +54,7 @@ public class WebSocketEventListener {
 
 		validateSessionIdPresent(sessionId);
 
-		AuthUser authUser = extractAuthUserFromAttributes(sessionUnsubscribeEvent);
+		final AuthUser authUser = extractAuthUserFromAttributes(sessionUnsubscribeEvent);
 		validateAuthUserPresent(authUser);
 		log.info("[✅ LOGGER] MEMBER {} IS LEFT CHATROOM", authUser.nickname());
 

--- a/src/test/java/com/dart/api/infrastructure/websocket/AuthChannelInterceptorTest.java
+++ b/src/test/java/com/dart/api/infrastructure/websocket/AuthChannelInterceptorTest.java
@@ -44,7 +44,7 @@ class AuthChannelInterceptorTest {
 		String accessToken = "testValidAccessToken";
 		AuthUser authUser = MemberFixture.createAuthUserEntity();
 
-		StompHeaderAccessor stompHeaderAccessor = StompHeaderAccessor.create(StompCommand.SEND);
+		StompHeaderAccessor stompHeaderAccessor = StompHeaderAccessor.create(StompCommand.CONNECT);
 		stompHeaderAccessor.setNativeHeader(ACCESS_TOKEN_HEADER, BEARER + BLANK + accessToken);
 		stompHeaderAccessor.setSessionAttributes(new HashMap<>());
 
@@ -68,7 +68,7 @@ class AuthChannelInterceptorTest {
 		// GIVEN
 		String accessToken = "testValidAccessToken";
 
-		StompHeaderAccessor stompHeaderAccessor = StompHeaderAccessor.create(StompCommand.SEND);
+		StompHeaderAccessor stompHeaderAccessor = StompHeaderAccessor.create(StompCommand.CONNECT);
 		stompHeaderAccessor.setNativeHeader(ACCESS_TOKEN_HEADER, BEARER + BLANK + accessToken);
 		stompHeaderAccessor.setSessionAttributes(new HashMap<>());
 


### PR DESCRIPTION
## 📋 CheckList
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. feat: 유저 조회 기능 구현)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

* close #300 

## 👩‍💻 공유 포인트 및 논의 사항
* 웹소켓 인증 및 인가를 담당하는 인터셉터에서 SEND를 하는 시점이 아닌 CONNECT 시점에 처리하도록 수정했습니다.
* 웹소켓 인터셉터가 우선순위에서 동작할 수 있도록 @Order 어노테이션을 적용했습니다.
