### PR TITLE
refactor: 실시간 접속 사용자 프로필 이미지 정보 전달

### DIFF
--- a/src/main/java/com/dart/api/application/chat/ChatMessageService.java
+++ b/src/main/java/com/dart/api/application/chat/ChatMessageService.java
@@ -109,7 +109,6 @@ public class ChatMessageService {
 	private void cachingChatMessages(ChatRoom chatRoom, List<ChatMessageReadDto> chatMessageReadDtoList) {
 		chatMessageReadDtoList.forEach(chatMessages -> {
 			final Member member = getMemberByNickname(chatMessages.sender());
-
 			final ChatMessage chatMessage = ChatMessage.chatMessageFromReadDto(chatRoom, member, chatMessages);
 			final ChatMessageSendDto chatMessageSendDto = chatMessage.toChatMessageSendDto(CHAT_MESSAGE_EXPIRY_SECONDS);
 

--- a/src/main/java/com/dart/api/dto/chat/response/MemberSessionDto.java
+++ b/src/main/java/com/dart/api/dto/chat/response/MemberSessionDto.java
@@ -3,6 +3,7 @@ package com.dart.api.dto.chat.response;
 public record MemberSessionDto(
 	String nickname,
 	String sessionId,
-	String destination
+	String destination,
+	String profileImageUrl
 ) {
 }

--- a/src/main/java/com/dart/api/infrastructure/websocket/MemberSessionRegistry.java
+++ b/src/main/java/com/dart/api/infrastructure/websocket/MemberSessionRegistry.java
@@ -16,8 +16,8 @@ public class MemberSessionRegistry {
 
 	private final Map<String, MemberSessionDto> memberSessionRegistry = new ConcurrentHashMap<>();
 
-	public void addSession(String nickname, String sessionId, String destination) {
-		MemberSessionDto memberSessionDto = new MemberSessionDto(nickname, sessionId, destination);
+	public void addSession(String nickname, String sessionId, String destination, String profileImageUrl) {
+		MemberSessionDto memberSessionDto = new MemberSessionDto(nickname, sessionId, destination, profileImageUrl);
 		memberSessionRegistry.put(sessionId, memberSessionDto);
 
 		log.info("[✅ LOGGER] SESSION ADDED: {}", memberSessionDto);
@@ -29,10 +29,9 @@ public class MemberSessionRegistry {
 		log.info("[✅ LOGGER] SESSION REMOVED: sessionId={}", sessionId);
 	}
 
-	public List<String> getMembersInChatRoom(String destination) {
-		List<String> members = memberSessionRegistry.values().stream()
+	public List<MemberSessionDto> getMembersInChatRoom(String destination) {
+		List<MemberSessionDto> members = memberSessionRegistry.values().stream()
 			.filter(session -> session.destination().equals(destination))
-			.map(MemberSessionDto::nickname)
 			.toList();
 
 		log.info("[✅ LOGGER] MEMBERS IN {}: {}", destination, members);

--- a/src/main/java/com/dart/api/presentation/ChatController.java
+++ b/src/main/java/com/dart/api/presentation/ChatController.java
@@ -47,7 +47,7 @@ public class ChatController {
 	}
 
 	@GetMapping("/api/chat-rooms/{chat-room-id}/members")
-	public ResponseEntity<List<String>> getLoggedInVisitors(@PathVariable("chat-room-id") Long chatRoomId) {
+	public ResponseEntity<List<MemberSessionDto>> getLoggedInVisitors(@PathVariable("chat-room-id") Long chatRoomId) {
 		return ResponseEntity.ok(memberSessionRegistry.getMembersInChatRoom("/sub/ws/" + chatRoomId));
 	}
 }

--- a/src/test/java/com/dart/api/infrastructure/websocket/MemberSessionRegistryTest.java
+++ b/src/test/java/com/dart/api/infrastructure/websocket/MemberSessionRegistryTest.java
@@ -26,14 +26,17 @@ class MemberSessionRegistryTest {
 		String sessionId = "testSessionId";
 		String chatRoomId = "1";
 		String destination = "/sub/ws/" + chatRoomId;
+		String profileImageUrl = "https://example.com/profile.jpg";
 
 		// WHEN
-		memberSessionRegistry.addSession(memberNickname, sessionId, destination);
+		memberSessionRegistry.addSession(memberNickname, sessionId, destination, profileImageUrl);
 
 		// THEN
-		List<String> members = memberSessionRegistry.getMembersInChatRoom(destination);
+		List<MemberSessionDto> members = memberSessionRegistry.getMembersInChatRoom(destination);
 		assertThat(members).hasSize(1);
-		assertThat(members.get(0)).isEqualTo(memberNickname);
+		MemberSessionDto memberSessionDto = members.get(0);
+		assertThat(memberSessionDto.nickname()).isEqualTo(memberNickname);
+		assertThat(memberSessionDto.profileImageUrl()).isEqualTo(profileImageUrl);
 	}
 
 	@Test
@@ -44,14 +47,15 @@ class MemberSessionRegistryTest {
 		String sessionId = "testSessionId";
 		String chatRoomId = "1";
 		String destination = "/sub/ws/" + chatRoomId;
+		String profileImageUrl = "https://example.com/profile.jpg";
 
-		memberSessionRegistry.addSession(memberNickname, sessionId, destination);
+		memberSessionRegistry.addSession(memberNickname, sessionId, destination, profileImageUrl);
 
 		// WHEN
 		memberSessionRegistry.removeSession(sessionId);
 
 		// THEN
-		List<String> members = memberSessionRegistry.getMembersInChatRoom(destination);
+		List<MemberSessionDto> members = memberSessionRegistry.getMembersInChatRoom(destination);
 		assertThat(members).isEmpty();
 	}
 
@@ -61,20 +65,27 @@ class MemberSessionRegistryTest {
 		// GIVEN
 		String destination1 = "/sub/ws/1";
 		String destination2 = "/sub/ws/2";
+		String profileImageURL1 = "https://example.com/profile1.jpg";
+		String profileImageURL2 = "https://example.com/profile2.jpg";
+		String profileImageURL3 = "https://example.com/profile3.jpg";
 
-		memberSessionRegistry.addSession("member1", "sessionId1", destination1);
-		memberSessionRegistry.addSession("member2", "sessionId2", destination1);
-		memberSessionRegistry.addSession("member3", "sessionId3", destination2);
+		memberSessionRegistry.addSession("member1", "sessionId1", destination1, profileImageURL1);
+		memberSessionRegistry.addSession("member2", "sessionId2", destination1, profileImageURL2);
+		memberSessionRegistry.addSession("member3", "sessionId3", destination2, profileImageURL3);
 
 		// WHEN
-		List<String> membersInDestination1 = memberSessionRegistry.getMembersInChatRoom(destination1);
-		List<String> membersInDestination2 = memberSessionRegistry.getMembersInChatRoom(destination2);
+		List<MemberSessionDto> membersInDestination1 = memberSessionRegistry.getMembersInChatRoom(destination1);
+		List<MemberSessionDto> membersInDestination2 = memberSessionRegistry.getMembersInChatRoom(destination2);
 
 		// THEN
 		assertThat(membersInDestination1).hasSize(2);
-		assertThat(membersInDestination1).containsExactlyInAnyOrder("member1", "member2");
+		assertThat(membersInDestination1).extracting("nickname")
+			.containsExactlyInAnyOrder("member1", "member2");
+		assertThat(membersInDestination1).extracting("profileImageUrl")
+			.containsExactlyInAnyOrder(profileImageURL1, profileImageURL2);
 
 		assertThat(membersInDestination2).hasSize(1);
-		assertThat(membersInDestination2.get(0)).isEqualTo("member3");
+		assertThat(membersInDestination2.get(0).nickname()).isEqualTo("member3");
+		assertThat(membersInDestination2.get(0).profileImageUrl()).isEqualTo(profileImageURL3);
 	}
 }

--- a/src/test/java/com/dart/api/presentation/ChatControllerTest.java
+++ b/src/test/java/com/dart/api/presentation/ChatControllerTest.java
@@ -69,12 +69,16 @@ class ChatControllerTest {
 		// GIVEN
 		Long chatRoomId = 1L;
 		String destination = "/sub/ws/" + chatRoomId;
-		List<String> members = Arrays.asList("member1", "member2", "member3");
+		List<MemberSessionDto> members = Arrays.asList(
+			new MemberSessionDto("member1", "sessionId1", destination, "https://example.com/profile1.jpg"),
+			new MemberSessionDto("member2", "sessionId2", destination, "https://example.com/profile2.jpg"),
+			new MemberSessionDto("member3", "sessionId3", destination, "https://example.com/profile3.jpg")
+		);
 
 		given(memberSessionRegistry.getMembersInChatRoom(destination)).willReturn(members);
 
 		// WHEN
-		ResponseEntity<List<String>> responseEntity = chatController.getLoggedInVisitors(chatRoomId);
+		ResponseEntity<List<MemberSessionDto>> responseEntity = chatController.getLoggedInVisitors(chatRoomId);
 
 		// THEN
 		assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -92,7 +96,7 @@ class ChatControllerTest {
 		given(memberSessionRegistry.getMembersInChatRoom(destination)).willReturn(List.of());
 
 		// WHEN
-		ResponseEntity<List<String>> responseEntity = chatController.getLoggedInVisitors(chatRoomId);
+		ResponseEntity<List<MemberSessionDto>> responseEntity = chatController.getLoggedInVisitors(chatRoomId);
 
 		// THEN
 		assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);

--- a/src/test/java/com/dart/integration/WebSocketMessageTest.java
+++ b/src/test/java/com/dart/integration/WebSocketMessageTest.java
@@ -114,22 +114,5 @@ public class WebSocketMessageTest {
 			15, TimeUnit.SECONDS
 		);
 	}
-
-	// @Test
-	// @DisplayName("WEB SOCKET MESSAGE(⭕️ SUCCESS): 성공적으로 메시지 전송 및 수신이 완료되었습니다.")
-	// void webSocketMessage_void_success() throws ExecutionException, InterruptedException, TimeoutException {
-	// 	// GIVEN
-	// 	String expectedContent = "Hello 👋🏻";
-	// 	ChatMessageCreateDto chatMessageCreateDto = new ChatMessageCreateDto(expectedContent);
-	//
-	// 	// WHEN
-	// 	stompSession.send("/pub/ws/" + chatRoomId + "/chat-messages", chatMessageCreateDto);
-	// 	System.out.println("MESSAGE SENT: " + expectedContent);
-	//
-	// 	// THEN
-	// 	String actualContent = completableFuture.get(15, TimeUnit.SECONDS);
-	// 	System.out.println("MESSAGE RECEIVED: " + actualContent);
-	// 	assertThat(actualContent).isEqualTo(expectedContent);
-	// }
 }
 


### PR DESCRIPTION
## 📋 CheckList
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. feat: 유저 조회 기능 구현)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

* close #314 

## 👩‍💻 공유 포인트 및 논의 사항
* 실시간 접속 사용자 정보를 조회할 때 사용자 닉네임만 클라이언트 측으로 넘기던 걸 프로필 이미지 URL도 함께 전달하도록 수정했습니다.
* 수정된 API 및 로직들의 테스트 코드들도 함께 수정했습니다.
