### PR TITLE
refactor: 클라이언트 측에서 메시지 전송 시 생성일자를 함께 요청할 수 있도록 수정

### DIFF
--- a/src/main/java/com/dart/api/application/chat/ChatMessageService.java
+++ b/src/main/java/com/dart/api/application/chat/ChatMessageService.java
@@ -9,7 +9,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,7 +39,6 @@ public class ChatMessageService {
 	private final MemberRepository memberRepository;
 	private final ChatRedisRepository chatRedisRepository;
 	private final ChatMessageRepository chatMessageRepository;
-	private final SimpMessageSendingOperations simpMessageSendingOperations;
 
 	@Transactional
 	public void saveChatMessage(Long chatRoomId, ChatMessageCreateDto chatMessageCreateDto,
@@ -55,8 +53,6 @@ public class ChatMessageService {
 
 		final ChatMessageSendDto chatMessageSendDto = chatMessage.toChatMessageSendDto(CHAT_MESSAGE_EXPIRY_SECONDS);
 		chatRedisRepository.saveChatMessage(chatMessageSendDto, member);
-
-		simpMessageSendingOperations.convertAndSend("/sub/ws/" + chatRoomId, chatMessageCreateDto.content());
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/dart/api/application/chat/ChatMessageService.java
+++ b/src/main/java/com/dart/api/application/chat/ChatMessageService.java
@@ -8,11 +8,9 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.dart.api.domain.auth.entity.AuthUser;
 import com.dart.api.domain.chat.entity.ChatMessage;
 import com.dart.api.domain.chat.entity.ChatRoom;
 import com.dart.api.domain.chat.repository.ChatMessageRepository;
@@ -26,7 +24,6 @@ import com.dart.api.dto.chat.response.ChatMessageReadDto;
 import com.dart.api.dto.page.PageInfo;
 import com.dart.api.dto.page.PageResponse;
 import com.dart.global.error.exception.NotFoundException;
-import com.dart.global.error.exception.UnauthorizedException;
 import com.dart.global.error.model.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
@@ -41,14 +38,10 @@ public class ChatMessageService {
 	private final ChatMessageRepository chatMessageRepository;
 
 	@Transactional
-	public void saveChatMessage(Long chatRoomId, ChatMessageCreateDto chatMessageCreateDto,
-		SimpMessageHeaderAccessor simpMessageHeaderAccessor
-	) {
+	public void saveChatMessage(Long chatRoomId, ChatMessageCreateDto chatMessageCreateDto) {
 		final ChatRoom chatRoom = getChatRoomById(chatRoomId);
-		final AuthUser authUser = extractAuthUserEmail(simpMessageHeaderAccessor);
-		final Member member = getMemberByEmail(authUser.email());
+		final Member member = getMemberByNickname(chatMessageCreateDto.nickname());
 		final ChatMessage chatMessage = ChatMessage.chatMessageFromCreateDto(chatRoom, member, chatMessageCreateDto);
-
 		chatMessageRepository.save(chatMessage);
 
 		final ChatMessageSendDto chatMessageSendDto = chatMessage.toChatMessageSendDto(CHAT_MESSAGE_EXPIRY_SECONDS);
@@ -68,18 +61,9 @@ public class ChatMessageService {
 		return createPageResponse(chatMessageReadDtoList, page, size);
 	}
 
-	private AuthUser extractAuthUserEmail(SimpMessageHeaderAccessor simpMessageHeaderAccessor) {
-		return (AuthUser)simpMessageHeaderAccessor.getSessionAttributes().get(CHAT_SESSION_USER);
-	}
-
 	private ChatRoom getChatRoomById(Long chatRoomId) {
 		return chatRoomRepository.findById(chatRoomId)
 			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_CHAT_ROOM_NOT_FOUND));
-	}
-
-	private Member getMemberByEmail(String email) {
-		return memberRepository.findByEmail(email)
-			.orElseThrow(() -> new UnauthorizedException(ErrorCode.FAIL_LOGIN_REQUIRED));
 	}
 
 	private Member getMemberByNickname(String nickname) {

--- a/src/main/java/com/dart/api/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/com/dart/api/domain/chat/entity/ChatMessage.java
@@ -52,9 +52,9 @@ public class ChatMessage {
 	private Member member;
 
 	@Builder
-	private ChatMessage(String content, boolean isAuthor, ChatRoom chatRoom, Member member) {
+	private ChatMessage(String content, LocalDateTime createdAt, boolean isAuthor, ChatRoom chatRoom, Member member) {
 		this.content = content;
-		this.createdAt = LocalDateTime.now();
+		this.createdAt = createdAt;
 		this.isAuthor = isAuthor;
 		this.chatRoom = chatRoom;
 		this.member = member;
@@ -66,9 +66,10 @@ public class ChatMessage {
 		ChatMessageCreateDto chatMessageCreateDto
 	) {
 		return ChatMessage.builder()
-			.chatRoom(chatRoom)
 			.content(chatMessageCreateDto.content())
-			.isAuthor(chatRoom.getGallery().getMember().equals(member))
+			.createdAt(chatMessageCreateDto.createdAt())
+			.isAuthor(chatMessageCreateDto.isAuthor())
+			.chatRoom(chatRoom)
 			.member(member)
 			.build();
 	}

--- a/src/main/java/com/dart/api/domain/coupon/repository/PriorityCouponRepository.java
+++ b/src/main/java/com/dart/api/domain/coupon/repository/PriorityCouponRepository.java
@@ -25,6 +25,6 @@ public interface PriorityCouponRepository extends JpaRepository<PriorityCoupon, 
 
 	List<PriorityCoupon> findByStartedAt(LocalDate startedAt);
 
-	@Query("SELECT p FROM PriorityCoupon p WHERE p.startedAt <= :nowDate")
+	@Query("SELECT p FROM PriorityCoupon p WHERE p.startedAt <= :nowDate ORDER BY p.startedAt DESC")
 	List<PriorityCoupon> findAllWithStartedAtBeforeOrEqual(@Param("nowDate") LocalDate nowDate);
 }

--- a/src/main/java/com/dart/api/dto/chat/request/ChatMessageCreateDto.java
+++ b/src/main/java/com/dart/api/dto/chat/request/ChatMessageCreateDto.java
@@ -1,13 +1,17 @@
 package com.dart.api.dto.chat.request;
 
-import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDateTime;
+
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
 @Builder
 public record ChatMessageCreateDto(
-	@NotBlank(message = "[❎ ERROR] 메시지 내용을 입력해주세요.")
-	@Size(max = 50)
-	String content
+	@Size(max = 50, message = "[❎ ERROR] 메시지 내용은 50자 이내여야 합니다.")
+	String content,
+	LocalDateTime createdAt,
+	String nickname,
+	String profileImageUrl,
+	boolean isAuthor
 ) {
 }

--- a/src/main/java/com/dart/api/presentation/ChatController.java
+++ b/src/main/java/com/dart/api/presentation/ChatController.java
@@ -8,8 +8,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
-import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -35,10 +35,9 @@ public class ChatController {
 	@MessageMapping(value = "/ws/{chat-room-id}/chat-messages")
 	public void saveAndSendChatMessage(
 		@DestinationVariable("chat-room-id") Long chatRoomId,
-		@Payload ChatMessageCreateDto chatMessageCreateDto,
-		SimpMessageHeaderAccessor simpMessageHeaderAccessor
+		@Payload @Validated ChatMessageCreateDto chatMessageCreateDto
 	) {
-		chatMessageService.saveChatMessage(chatRoomId, chatMessageCreateDto, simpMessageHeaderAccessor);
+		chatMessageService.saveChatMessage(chatRoomId, chatMessageCreateDto);
 		simpMessageSendingOperations.convertAndSend(TOPIC_PREFIX + chatRoomId, chatMessageCreateDto.content());
 	}
 

--- a/src/main/java/com/dart/api/presentation/ChatController.java
+++ b/src/main/java/com/dart/api/presentation/ChatController.java
@@ -1,5 +1,7 @@
 package com.dart.api.presentation;
 
+import static com.dart.global.common.util.ChatConstant.*;
+
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
@@ -7,6 +9,7 @@ import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -25,6 +28,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ChatController {
 
+	private final SimpMessageSendingOperations simpMessageSendingOperations;
 	private final ChatMessageService chatMessageService;
 	private final MemberSessionRegistry memberSessionRegistry;
 
@@ -35,6 +39,7 @@ public class ChatController {
 		SimpMessageHeaderAccessor simpMessageHeaderAccessor
 	) {
 		chatMessageService.saveChatMessage(chatRoomId, chatMessageCreateDto, simpMessageHeaderAccessor);
+		simpMessageSendingOperations.convertAndSend(TOPIC_PREFIX + chatRoomId, chatMessageCreateDto.content());
 	}
 
 	@GetMapping("/api/{chat-room-id}/chat-messages")
@@ -48,6 +53,6 @@ public class ChatController {
 
 	@GetMapping("/api/chat-rooms/{chat-room-id}/members")
 	public ResponseEntity<List<MemberSessionDto>> getLoggedInVisitors(@PathVariable("chat-room-id") Long chatRoomId) {
-		return ResponseEntity.ok(memberSessionRegistry.getMembersInChatRoom("/sub/ws/" + chatRoomId));
+		return ResponseEntity.ok(memberSessionRegistry.getMembersInChatRoom(TOPIC_PREFIX + chatRoomId));
 	}
 }

--- a/src/main/java/com/dart/global/common/util/ChatConstant.java
+++ b/src/main/java/com/dart/global/common/util/ChatConstant.java
@@ -11,9 +11,8 @@ public class ChatConstant {
 	public static final String APPLICATION_DESTINATION_PREFIX = "/pub";
 	public static final String ALLOWED_ORIGIN_PATTERN = "*";
 	public static final String CHAT_SESSION_USER = "authUser";
-	public final static String SORT_FIELD_CREATED_AT = "createdAt";
+	public static final String TOPIC_PREFIX = "/sub/ws/";
 	public final static long CHAT_MESSAGE_EXPIRY_SECONDS = 60 * 60;
-	public static final String STOMP_COMMAND_HEADER = "stompCommand";
 
 	public static final int MESSAGE_SIZE_LIMIT = 160 * 64 * 1024;
 	public static final int SEND_TIME_LIMIT = 100 * 10000;

--- a/src/test/java/com/dart/api/application/chat/ChatMessageServiceTest.java
+++ b/src/test/java/com/dart/api/application/chat/ChatMessageServiceTest.java
@@ -1,4 +1,3 @@
-/*
 package com.dart.api.application.chat;
 
 import static com.dart.global.common.util.ChatConstant.*;
@@ -22,7 +21,6 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
 
 import com.dart.api.domain.chat.entity.ChatMessage;
 import com.dart.api.domain.chat.entity.ChatRoom;
@@ -49,9 +47,6 @@ class ChatMessageServiceTest {
 
 	@Mock
 	private MemberRepository memberRepository;
-
-	@Mock
-	private SimpMessageSendingOperations simpMessageSendingOperations;
 
 	@Mock
 	private ChatRedisRepository chatRedisRepository;
@@ -85,7 +80,6 @@ class ChatMessageServiceTest {
 		// THEN
 		verify(chatMessageRepository, times(1)).save(any(ChatMessage.class));
 		verify(chatRedisRepository, times(1)).saveChatMessage(any(ChatMessageSendDto.class), any(Member.class));
-		verify(simpMessageSendingOperations, times(1)).convertAndSend(anyString(), anyString());
 	}
 
 	@Test
@@ -197,4 +191,3 @@ class ChatMessageServiceTest {
 		verify(chatRedisRepository, times(1)).saveChatMessage(any(ChatMessageSendDto.class), any(Member.class));
 	}
 }
-*/

--- a/src/test/java/com/dart/api/application/chat/ChatRoomServiceTest.java
+++ b/src/test/java/com/dart/api/application/chat/ChatRoomServiceTest.java
@@ -14,6 +14,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.dart.api.domain.chat.entity.ChatRoom;
+import com.dart.api.domain.chat.repository.ChatMessageRepository;
 import com.dart.api.domain.chat.repository.ChatRedisRepository;
 import com.dart.api.domain.chat.repository.ChatRoomRepository;
 import com.dart.api.domain.gallery.entity.Gallery;
@@ -26,6 +27,9 @@ class ChatRoomServiceTest {
 
 	@Mock
 	private ChatRoomRepository chatRoomRepository;
+
+	@Mock
+	private ChatMessageRepository chatMessageRepository;
 
 	@Mock
 	private ChatRedisRepository chatRedisRepository;
@@ -60,6 +64,7 @@ class ChatRoomServiceTest {
 
 		// THEN
 		verify(chatRoomRepository).findByGallery(gallery);
+		verify(chatMessageRepository).deleteByChatRoom(chatRoom);
 		verify(chatRedisRepository).deleteChatMessages(chatRoom.getId());
 		verify(chatRoomRepository).delete(chatRoom);
 	}

--- a/src/test/java/com/dart/api/infrastructure/websocket/WebSocketEventListenerTest.java
+++ b/src/test/java/com/dart/api/infrastructure/websocket/WebSocketEventListenerTest.java
@@ -59,7 +59,7 @@ class WebSocketEventListenerTest {
 		// GIVEN
 		String sessionId = "testSessionId";
 		String chatRoomId = "1";
-		String destination = "/sub/ws/" + chatRoomId;
+		String destination = TOPIC_PREFIX + chatRoomId;
 
 		AuthUser authUser = MemberFixture.createAuthUserEntity();
 		Member member = MemberFixture.createMemberEntity();
@@ -92,7 +92,7 @@ class WebSocketEventListenerTest {
 	void handleSubscribeEvent_sessionId_BadRequestException_fail() {
 		// GIVEN
 		String chatRoomId = "1";
-		String destination = "/sub/ws/" + chatRoomId;
+		String destination = TOPIC_PREFIX + chatRoomId;
 
 		AuthUser authUser = MemberFixture.createAuthUserEntity();
 

--- a/src/test/java/com/dart/api/presentation/ChatControllerTest.java
+++ b/src/test/java/com/dart/api/presentation/ChatControllerTest.java
@@ -61,10 +61,10 @@ class ChatControllerTest {
 		given(simpMessageHeaderAccessor.getSessionAttributes()).willReturn(sessionAttributes);
 
 		// WHEN
-		chatController.saveAndSendChatMessage(chatRoomId, chatMessageCreateDto, simpMessageHeaderAccessor);
+		chatController.saveAndSendChatMessage(chatRoomId, chatMessageCreateDto);
 
 		// THEN
-		verify(chatMessageService).saveChatMessage(chatRoomId, chatMessageCreateDto, simpMessageHeaderAccessor);
+		verify(chatMessageService).saveChatMessage(chatRoomId, chatMessageCreateDto);
 		verify(simpMessageSendingOperations).convertAndSend(TOPIC_PREFIX + chatRoomId, chatMessageCreateDto.content());
 	}
 

--- a/src/test/java/com/dart/api/presentation/ChatControllerTest.java
+++ b/src/test/java/com/dart/api/presentation/ChatControllerTest.java
@@ -17,6 +17,7 @@ import org.mockito.Mock;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.dart.api.application.chat.ChatMessageService;
@@ -32,6 +33,9 @@ class ChatControllerTest {
 
 	@Mock
 	private ChatMessageService chatMessageService;
+
+	@Mock
+	private SimpMessageSendingOperations simpMessageSendingOperations;
 
 	@Mock
 	private SimpMessageHeaderAccessor simpMessageHeaderAccessor;
@@ -61,6 +65,7 @@ class ChatControllerTest {
 
 		// THEN
 		verify(chatMessageService).saveChatMessage(chatRoomId, chatMessageCreateDto, simpMessageHeaderAccessor);
+		verify(simpMessageSendingOperations).convertAndSend(TOPIC_PREFIX + chatRoomId, chatMessageCreateDto.content());
 	}
 
 	@Test

--- a/src/test/java/com/dart/support/ChatFixture.java
+++ b/src/test/java/com/dart/support/ChatFixture.java
@@ -4,8 +4,10 @@ import static com.dart.global.common.util.ChatConstant.*;
 
 import java.time.LocalDateTime;
 
+import com.dart.api.domain.chat.entity.ChatMessage;
 import com.dart.api.domain.chat.entity.ChatRoom;
 import com.dart.api.domain.gallery.entity.Gallery;
+import com.dart.api.domain.member.entity.Member;
 import com.dart.api.dto.chat.request.ChatMessageCreateDto;
 import com.dart.api.dto.chat.request.ChatMessageSendDto;
 
@@ -22,9 +24,25 @@ public class ChatFixture {
 			.build();
 	}
 
+	public static ChatMessage createChatMessageEntity(ChatRoom chatRoom, Member member,
+		ChatMessageCreateDto chatMessageCreateDto
+	) {
+		return ChatMessage.builder()
+			.content(chatMessageCreateDto.content())
+			.createdAt(chatMessageCreateDto.createdAt())
+			.isAuthor(chatMessageCreateDto.isAuthor())
+			.chatRoom(chatRoom)
+			.member(member)
+			.build();
+	}
+
 	public static ChatMessageCreateDto createChatMessageEntityForChatMessageCreateDto() {
 		return ChatMessageCreateDto.builder()
 			.content("Hello 👋🏻")
+			.createdAt(LocalDateTime.now())
+			.nickname("test1")
+			.profileImageUrl("https://example.com/profile.jpg")
+			.isAuthor(false)
 			.build();
 	}
 

--- a/src/test/java/com/dart/support/GalleryFixture.java
+++ b/src/test/java/com/dart/support/GalleryFixture.java
@@ -3,10 +3,6 @@ package com.dart.support;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.web.multipart.MultipartFile;
-
 import com.dart.api.domain.gallery.entity.Cost;
 import com.dart.api.domain.gallery.entity.Gallery;
 import com.dart.api.domain.member.entity.Member;
@@ -24,15 +20,6 @@ public class GalleryFixture {
 		);
 	}
 
-	public static Gallery createGalleryEntityForAuthor() {
-		return Gallery.create(
-			createGalleryEntityForCreateGalleryDto(),
-			"https://example.com/thumbnail.jpg",
-			Cost.FREE,
-			MemberFixture.createMemberEntityForAuthor()
-		);
-	}
-
 	public static Gallery createGalleryEntity(Member member) {
 		return Gallery.builder()
 			.title("D'ART Gallery")
@@ -43,32 +30,6 @@ public class GalleryFixture {
 			.cost(Cost.FREE)
 			.fee(0)
 			.member(member)
-			.build();
-	}
-
-	public static Gallery createFreeGalleryEntity() {
-		return Gallery.builder()
-			.title("D'ART Gallery")
-			.content("This is D'ART Gallery")
-			.thumbnail("https://example.com/thumbnail.jpg")
-			.startDate(LocalDateTime.now())
-			.endDate(null)
-			.cost(Cost.FREE)
-			.fee(0)
-			.member(MemberFixture.createMemberEntity())
-			.build();
-	}
-
-	public static Gallery createPaidGalleryEntity(LocalDateTime startDate, LocalDateTime endDate) {
-		return Gallery.builder()
-			.title("D'ART Gallery")
-			.content("This is D'ART Gallery")
-			.thumbnail("https://example.com/thumbnail.jpg")
-			.startDate(startDate)
-			.endDate(endDate)
-			.cost(Cost.PAY)
-			.fee(1000)
-			.member(MemberFixture.createMemberEntity())
 			.build();
 	}
 
@@ -86,32 +47,5 @@ public class GalleryFixture {
 				new ImageInfoDto("image2.jpg", "Image 2"))
 			)
 			.build();
-	}
-
-	public static MultipartFile createMultipartFileForThumbnail() {
-		return new MockMultipartFile(
-			"thumbnail",
-			"thumbnail.png",
-			MediaType.IMAGE_PNG_VALUE,
-			"Thumbnail Content".getBytes()
-		);
-	}
-
-	public static List<MultipartFile> createMultipartFileForImages() {
-		MockMultipartFile imageFile1 = new MockMultipartFile(
-			"imageFiles",
-			"image1.png",
-			MediaType.IMAGE_PNG_VALUE,
-			"Image1 Content".getBytes()
-		);
-
-		MockMultipartFile imageFile2 = new MockMultipartFile(
-			"imageFiles",
-			"image2.png",
-			MediaType.IMAGE_PNG_VALUE,
-			"Image2 Content".getBytes()
-		);
-
-		return List.of(imageFile1, imageFile2);
 	}
 }

--- a/src/test/java/com/dart/support/MemberFixture.java
+++ b/src/test/java/com/dart/support/MemberFixture.java
@@ -10,51 +10,22 @@ public class MemberFixture {
 
 	public static Member createMemberEntity() {
 		return Member.signup(
-			createMemberEntityForSignUpDto(),
+			createSignUpDto("test1@example.com", "test1"),
 			"1q2w3e4r!"
 		);
 	}
 
-	public static Member createMemberEntityForAuthor() {
-		return Member.signup(
-			createMemberEntityForAuthorSignUpDto(),
-			"1q2w3e4r!"
-		);
+	public static AuthUser createAuthUserEntity() {
+		return AuthUser.create(1L, "test1@example.com", "test1");
 	}
 
-	public static SignUpDto createMemberEntityForSignUpDto() {
+	public static SignUpDto createSignUpDto(String email, String nickname) {
 		return SignUpDto.builder()
-			.email("test1@example.com")
-			.nickname("test1")
+			.email(email)
+			.nickname(nickname)
 			.password("1q2w3e4r!")
 			.birthday(LocalDate.of(2024, 6, 4))
 			.introduce("Hello 👏")
 			.build();
-	}
-
-	public static SignUpDto createMemberEntityForAuthorSignUpDto() {
-		return SignUpDto.builder()
-			.email("author@example.com")
-			.nickname("author")
-			.password("1q2w3e4r!")
-			.birthday(LocalDate.of(2024, 6, 4))
-			.introduce("Have a good time 👏")
-			.build();
-	}
-
-	public static AuthUser createAuthUserEntity() {
-		return AuthUser.create(
-			1L,
-			"test1@example.com",
-			"test1"
-		);
-	}
-
-	public static AuthUser createAuthUserEntityForAuthor() {
-		return AuthUser.create(
-			1L,
-			"author@example.com",
-			"author"
-		);
 	}
 }


### PR DESCRIPTION
## 📋 CheckList
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. feat: 유저 조회 기능 구현)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

* close #339 

## 👩‍💻 공유 포인트 및 논의 사항
* 채팅메시지 저장 및 전송 로직에서 각 컨트롤러와 서비스 레이어에 맞는 역할을 수행하도록 리팩토링했습니다.
* 클라이언트 측에서 요청한 값을 통해 채팅메시지를 전송 및 저장할 수 있도록 서비스 로직을 수정했습니다.
* 실시간 쿠폰을 시작날짜 혹은 그와 동일한 날짜일 경우 모든 실시간 쿠폰을 조회하는 로직의 쿼리를 수정했습니다.
* 수정된 채팅메시지 서비스 로직들에 맞도록 테스트 코드들을 수정했습니다.
* 각 Mock 객체들을 생성하는 Fixture 클래스에서 불필요한 로직들을 제거 및 리팩토링을 진행했습니다.
