### PR TITLE
refactor: 결제 로직 분리 & 동시성 이슈를 해결

### DIFF
--- a/src/main/java/com/dart/api/application/gallery/GalleryService.java
+++ b/src/main/java/com/dart/api/application/gallery/GalleryService.java
@@ -24,7 +24,7 @@ import com.dart.api.domain.gallery.entity.Template;
 import com.dart.api.domain.gallery.repository.GalleryRepository;
 import com.dart.api.domain.member.entity.Member;
 import com.dart.api.domain.member.repository.MemberRepository;
-import com.dart.api.domain.payment.entity.Order;
+import com.dart.api.domain.payment.entity.OrderType;
 import com.dart.api.domain.payment.repository.PaymentRedisRepository;
 import com.dart.api.domain.payment.repository.PaymentRepository;
 import com.dart.api.domain.review.repository.ReviewRepository;
@@ -288,7 +288,7 @@ public class GalleryService {
 			return true;
 		}
 
-		return paymentRepository.existsByMemberAndGalleryIdAndOrder(member, gallery.getId(), Order.TICKET);
+		return paymentRepository.existsByMemberAndGalleryIdAndOrderType(member, gallery.getId(), OrderType.TICKET);
 	}
 
 	private boolean checkIfUserHasCommented(Gallery gallery, AuthUser authUser) {

--- a/src/main/java/com/dart/api/application/payment/KakaoPayApproveService.java
+++ b/src/main/java/com/dart/api/application/payment/KakaoPayApproveService.java
@@ -33,10 +33,8 @@ import com.dart.global.error.exception.NotFoundException;
 import com.dart.global.error.model.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 @Service
-@Slf4j
 @Transactional
 @RequiredArgsConstructor
 public class KakaoPayApproveService {
@@ -53,8 +51,6 @@ public class KakaoPayApproveService {
 		Long galleryId) {
 		final Order order = orderRepository.findByMemberIdAndGalleryId(memberId, galleryId)
 			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_ORDER_NOT_FOUND));
-		log.info("{order----------------------------}" + order.getTid() + "  galleryid :    " + order.getGalleryId());
-
 		final MultiValueMap<String, String> params = approveToBody(token, order);
 		final HttpHeaders headers = setHeaders();
 		final RestTemplate restTemplate = new RestTemplate();
@@ -71,18 +67,12 @@ public class KakaoPayApproveService {
 		final Payment payment = Payment.create(member, gallery, paymentApproveDto.amount().total(), approveAt,
 			orderType);
 
+		order.approve();
 		payGallery(orderType, gallery);
 		useCoupon(couponId, isPriority, member);
 		paymentRepository.save(payment);
 
 		return gallery.getId().toString();
-	}
-
-	public void cancel(Long memberId, Long galleryId) {
-		final Order order = orderRepository.findByMemberIdAndGalleryId(memberId, galleryId)
-			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_ORDER_NOT_FOUND));
-
-		orderRepository.delete(order);
 	}
 
 	public MultiValueMap<String, String> approveToBody(String token, Order order) {

--- a/src/main/java/com/dart/api/application/payment/KakaoPayApproveService.java
+++ b/src/main/java/com/dart/api/application/payment/KakaoPayApproveService.java
@@ -1,0 +1,142 @@
+package com.dart.api.application.payment;
+
+import static com.dart.global.common.util.PaymentConstant.*;
+
+import java.time.LocalDateTime;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import com.dart.api.domain.coupon.entity.GeneralCouponWallet;
+import com.dart.api.domain.coupon.entity.PriorityCouponWallet;
+import com.dart.api.domain.coupon.repository.GeneralCouponWalletRepository;
+import com.dart.api.domain.coupon.repository.PriorityCouponWalletRepository;
+import com.dart.api.domain.gallery.entity.Gallery;
+import com.dart.api.domain.gallery.repository.GalleryRepository;
+import com.dart.api.domain.member.entity.Member;
+import com.dart.api.domain.member.repository.MemberRepository;
+import com.dart.api.domain.payment.entity.Order;
+import com.dart.api.domain.payment.entity.OrderType;
+import com.dart.api.domain.payment.entity.Payment;
+import com.dart.api.domain.payment.repository.OrderRepository;
+import com.dart.api.domain.payment.repository.PaymentRedisRepository;
+import com.dart.api.domain.payment.repository.PaymentRepository;
+import com.dart.api.dto.payment.response.PaymentApproveDto;
+import com.dart.global.config.PaymentProperties;
+import com.dart.global.error.exception.NotFoundException;
+import com.dart.global.error.model.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+@Transactional
+@RequiredArgsConstructor
+public class KakaoPayApproveService {
+	private final GalleryRepository galleryRepository;
+	private final PaymentProperties paymentProperties;
+	private final MemberRepository memberRepository;
+	private final PaymentRedisRepository paymentRedisRepository;
+	private final PaymentRepository paymentRepository;
+	private final GeneralCouponWalletRepository generalCouponWalletRepository;
+	private final PriorityCouponWalletRepository priorityCouponWalletRepository;
+	private final OrderRepository orderRepository;
+
+	public String approve(String token, Long memberId, String orderType, Long couponId, boolean isPriority,
+		Long galleryId) {
+		final Order order = orderRepository.findByMemberIdAndGalleryId(memberId, galleryId)
+			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_ORDER_NOT_FOUND));
+		log.info("{order----------------------------}" + order.getTid() + "  galleryid :    " + order.getGalleryId());
+
+		final MultiValueMap<String, String> params = approveToBody(token, order);
+		final HttpHeaders headers = setHeaders();
+		final RestTemplate restTemplate = new RestTemplate();
+		final HttpEntity<MultiValueMap<String, String>> body = new HttpEntity<>(params, headers);
+		final PaymentApproveDto paymentApproveDto = restTemplate.postForObject(
+			APPROVE_URL,
+			body,
+			PaymentApproveDto.class);
+		final Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_MEMBER_NOT_FOUND));
+		final Gallery gallery = galleryRepository.findById(order.getGalleryId())
+			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_GALLERY_NOT_FOUND));
+		final LocalDateTime approveAt = paymentApproveDto.approved_at();
+		final Payment payment = Payment.create(member, gallery, paymentApproveDto.amount().total(), approveAt,
+			orderType);
+
+		payGallery(orderType, gallery);
+		useCoupon(couponId, isPriority, member);
+		paymentRepository.save(payment);
+
+		return gallery.getId().toString();
+	}
+
+	public void cancel(Long memberId, Long galleryId) {
+		final Order order = orderRepository.findByMemberIdAndGalleryId(memberId, galleryId)
+			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_ORDER_NOT_FOUND));
+
+		orderRepository.delete(order);
+	}
+
+	public MultiValueMap<String, String> approveToBody(String token, Order order) {
+		final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+
+		params.add("cid", CID);
+		params.add("tid", order.getTid());
+		params.add("partner_order_id", order.getGalleryId().toString());
+		params.add("partner_user_id", order.getMemberId().toString());
+		params.add("pg_token", token);
+
+		return params;
+	}
+
+	public HttpHeaders setHeaders() {
+		final HttpHeaders headers = new HttpHeaders();
+
+		headers.add("Authorization", "KakaoAK " + paymentProperties.getAdminKey());
+		headers.add("Accept", MediaType.APPLICATION_JSON_VALUE);
+		headers.add("Content-Type", MediaType.APPLICATION_FORM_URLENCODED_VALUE + ";charset=UTF-8");
+
+		return headers;
+	}
+
+	private void useCoupon(Long couponId, boolean isPriority, Member member) {
+		if (couponId != FREE) {
+			if (isPriority) {
+				final PriorityCouponWallet priorityCouponWallet = findPriorityCouponWallet(member.getId(), couponId);
+				priorityCouponWallet.use();
+
+				return;
+			}
+
+			final GeneralCouponWallet generalCouponWallet = findGeneralCouponWallet(member.getId(), couponId);
+			generalCouponWallet.use();
+		}
+	}
+
+	private PriorityCouponWallet findPriorityCouponWallet(Long memberId, Long couponId) {
+		return priorityCouponWalletRepository
+			.findByMemberIdAndPriorityCouponIdAndIsUsedFalse(memberId, couponId)
+			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_COUPON_NOT_FOUND));
+	}
+
+	private GeneralCouponWallet findGeneralCouponWallet(Long memberId, Long couponId) {
+		return generalCouponWalletRepository
+			.findByMemberIdAndGeneralCouponIdAndIsUsedFalse(memberId, couponId)
+			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_COUPON_NOT_FOUND));
+	}
+
+	private void payGallery(String orderType, Gallery gallery) {
+		if (orderType.equals(OrderType.PAID_GALLERY.getValue())) {
+			gallery.pay();
+			paymentRedisRepository.deleteData(gallery.getId().toString());
+		}
+	}
+}

--- a/src/main/java/com/dart/api/application/payment/KakaoPayReadyService.java
+++ b/src/main/java/com/dart/api/application/payment/KakaoPayReadyService.java
@@ -75,12 +75,6 @@ public class KakaoPayReadyService {
 		return paymentReadyDto;
 	}
 
-	private void validateAlreadyPayments(PaymentCreateDto dto, Member member) {
-		if (orderRepository.existsByMemberIdAndGalleryIdAndIsApprovedTrue(member.getId(), dto.galleryId())) {
-			throw new ConflictException(ErrorCode.FAIL_PAYMENT_CONFLICT);
-		}
-	}
-
 	private MultiValueMap<String, String> readyToBody(PaymentCreateDto dto, Long memberId) {
 		final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
 		final Gallery gallery = galleryRepository.findById(dto.galleryId())
@@ -157,6 +151,12 @@ public class KakaoPayReadyService {
 		return generalCouponWalletRepository
 			.findByMemberIdAndGeneralCouponIdAndIsUsedFalse(memberId, couponId)
 			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_COUPON_NOT_FOUND));
+	}
+
+	private void validateAlreadyPayments(PaymentCreateDto dto, Member member) {
+		if (orderRepository.existsByMemberIdAndGalleryIdAndIsApprovedTrue(member.getId(), dto.galleryId())) {
+			throw new ConflictException(ErrorCode.FAIL_PAYMENT_CONFLICT);
+		}
 	}
 
 	private void deleteUnpaidOrder(PaymentCreateDto dto, Member member) {

--- a/src/main/java/com/dart/api/application/payment/KakaoPayReadyService.java
+++ b/src/main/java/com/dart/api/application/payment/KakaoPayReadyService.java
@@ -2,8 +2,6 @@ package com.dart.api.application.payment;
 
 import static com.dart.global.common.util.PaymentConstant.*;
 
-import java.time.LocalDateTime;
-
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -23,31 +21,32 @@ import com.dart.api.domain.gallery.repository.GalleryRepository;
 import com.dart.api.domain.member.entity.Member;
 import com.dart.api.domain.member.repository.MemberRepository;
 import com.dart.api.domain.payment.entity.Order;
-import com.dart.api.domain.payment.entity.Payment;
-import com.dart.api.domain.payment.repository.PaymentRedisRepository;
+import com.dart.api.domain.payment.entity.OrderType;
+import com.dart.api.domain.payment.repository.OrderRepository;
 import com.dart.api.domain.payment.repository.PaymentRepository;
 import com.dart.api.dto.payment.request.PaymentCreateDto;
-import com.dart.api.dto.payment.response.PaymentApproveDto;
 import com.dart.api.dto.payment.response.PaymentReadyDto;
 import com.dart.global.config.PaymentProperties;
 import com.dart.global.error.exception.BadRequestException;
+import com.dart.global.error.exception.ConflictException;
 import com.dart.global.error.exception.NotFoundException;
 import com.dart.global.error.model.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
+@Slf4j
 @Transactional
 @RequiredArgsConstructor
-public class KakaoPayService {
+public class KakaoPayReadyService {
 	private final GalleryRepository galleryRepository;
 	private final PaymentProperties paymentProperties;
 	private final MemberRepository memberRepository;
-	private final PaymentRedisRepository paymentRedisRepository;
 	private final PaymentRepository paymentRepository;
 	private final GeneralCouponWalletRepository generalCouponWalletRepository;
 	private final PriorityCouponWalletRepository priorityCouponWalletRepository;
-	private PaymentReadyDto paymentReadyDto;
+	private final OrderRepository orderRepository;
 
 	public PaymentReadyDto ready(PaymentCreateDto dto, AuthUser authUser) {
 		validateExistGallery(dto);
@@ -63,34 +62,18 @@ public class KakaoPayService {
 		final HttpHeaders headers = setHeaders();
 		final HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(params, headers);
 		final RestTemplate restTemplate = new RestTemplate();
-
-		return paymentReadyDto = restTemplate.postForObject(
+		final PaymentReadyDto paymentReadyDto = restTemplate.postForObject(
 			READY_URL,
 			requestEntity,
-			PaymentReadyDto.class);
-	}
+			PaymentReadyDto.class
+		);
 
-	public String approve(String token, Long id, String order, Long couponId, boolean isPriority) {
-		final MultiValueMap<String, String> params = approveToBody(token);
-		final HttpHeaders headers = setHeaders();
-		final RestTemplate restTemplate = new RestTemplate();
-		final HttpEntity<MultiValueMap<String, String>> body = new HttpEntity<>(params, headers);
-		final PaymentApproveDto paymentApproveDto = restTemplate.postForObject(
-			APPROVE_URL,
-			body,
-			PaymentApproveDto.class);
-		final Member member = memberRepository.findById(id)
-			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_MEMBER_NOT_FOUND));
-		final Gallery gallery = galleryRepository.findById(Long.parseLong(paymentApproveDto.item_code()))
-			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_GALLERY_NOT_FOUND));
-		final LocalDateTime approveAt = paymentApproveDto.approved_at();
-		final Payment payment = Payment.create(member, gallery, paymentApproveDto.amount().total(), approveAt, order);
+		validateAlreadyPayment(dto, member);
 
-		payGallery(order, gallery);
-		useCoupon(couponId, isPriority, member);
-		paymentRepository.save(payment);
+		final Order order = Order.create(paymentReadyDto.tid(), member.getId(), dto.galleryId());
+		orderRepository.save(order);
 
-		return gallery.getId().toString();
+		return paymentReadyDto;
 	}
 
 	public MultiValueMap<String, String> readyToBody(PaymentCreateDto dto, Long memberId) {
@@ -99,55 +82,20 @@ public class KakaoPayService {
 			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_GALLERY_NOT_FOUND));
 
 		params.add("cid", CID);
-		params.add("partner_order_id", PARTNER_ORDER);
-		params.add("partner_user_id", PARTNER_USER);
-		params.add("item_name", String.valueOf(gallery.getTitle()));
+		params.add("partner_order_id", dto.galleryId().toString());
+		params.add("partner_user_id", memberId.toString());
+		params.add("item_name", gallery.getTitle());
 		params.add("item_code", gallery.getId().toString());
 		params.add("quantity", QUANTITY);
 		params.add("total_amount", decideCost(dto, gallery, memberId));
 		params.add("tax_free_amount", TAX);
 		params.add("approval_url",
-			SUCCESS_URL + "/" + memberId + "/" + dto.order() + "/" + dto.couponId() + "/" + dto.isPriority());
-		params.add("cancel_url", CANCEL_URL);
+			SUCCESS_URL + "/" + memberId + "/" + dto.order() + "/" + dto.couponId() + "/" + dto.isPriority() + "/"
+				+ dto.galleryId());
+		params.add("cancel_url", CANCEL_URL + "/" + memberId + "/" + dto.galleryId());
 		params.add("fail_url", FAIL_URL);
 
 		return params;
-	}
-
-	public MultiValueMap<String, String> approveToBody(String token) {
-		final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-
-		params.add("cid", CID);
-		params.add("tid", paymentReadyDto.tid());
-		params.add("partner_order_id", PARTNER_ORDER);
-		params.add("partner_user_id", PARTNER_USER);
-		params.add("pg_token", token);
-
-		return params;
-	}
-
-	public HttpHeaders setHeaders() {
-		final HttpHeaders headers = new HttpHeaders();
-
-		headers.add("Authorization", "KakaoAK " + paymentProperties.getAdminKey());
-		headers.add("Accept", MediaType.APPLICATION_JSON_VALUE);
-		headers.add("Content-Type", MediaType.APPLICATION_FORM_URLENCODED_VALUE + ";charset=UTF-8");
-
-		return headers;
-	}
-
-	private void useCoupon(Long couponId, boolean isPriority, Member member) {
-		if (couponId != FREE) {
-			if (isPriority) {
-				final PriorityCouponWallet priorityCouponWallet = findPriorityCouponWallet(member.getId(), couponId);
-				priorityCouponWallet.use();
-
-				return;
-			}
-
-			final GeneralCouponWallet generalCouponWallet = findGeneralCouponWallet(member.getId(), couponId);
-			generalCouponWallet.use();
-		}
 	}
 
 	public String decideCost(PaymentCreateDto dto, Gallery gallery, Long memberId) {
@@ -168,42 +116,18 @@ public class KakaoPayService {
 			generalCouponWallet.getGeneralCoupon().getCouponType().getValue());
 	}
 
-	private void validateAlreadyTicket(PaymentCreateDto dto, Member member) {
-		if (dto.order().equals(Order.TICKET.getValue()) && paymentRepository.existsByMemberAndGalleryIdAndOrder(member,
-			dto.galleryId(), Order.TICKET)) {
-			throw new BadRequestException(ErrorCode.FAIL_ALREADY_PAID_TICKET);
+	public HttpHeaders setHeaders() {
+		final HttpHeaders headers = new HttpHeaders();
 
-		}
-	}
+		headers.add("Authorization", "KakaoAK " + paymentProperties.getAdminKey());
+		headers.add("Accept", MediaType.APPLICATION_JSON_VALUE);
+		headers.add("Content-Type", MediaType.APPLICATION_FORM_URLENCODED_VALUE + ";charset=UTF-8");
 
-	private void validateAlreadyGallery(PaymentCreateDto dto, Member member) {
-		if (dto.order().equals(Order.PAID_GALLERY.getValue()) && paymentRepository.existsByMemberAndGalleryIdAndOrder(
-			member, dto.galleryId(), Order.PAID_GALLERY)) {
-			throw new BadRequestException(ErrorCode.FAIL_ALREADY_PAID_GALLERY);
-		}
-	}
-
-	private void payGallery(String order, Gallery gallery) {
-		if (order.equals(Order.PAID_GALLERY.getValue())) {
-			gallery.pay();
-			paymentRedisRepository.deleteData(gallery.getId().toString());
-		}
-	}
-
-	private static void validateOrder(String order) {
-		if (!Order.contains(order)) {
-			throw new BadRequestException(ErrorCode.FAIL_INVALID_ORDER);
-		}
-	}
-
-	private void validateExistGallery(PaymentCreateDto dto) {
-		if (dto.order().equals(Order.TICKET.getValue()) && !galleryRepository.findIsPaidById(dto.galleryId())) {
-			throw new BadRequestException(ErrorCode.FAIL_NOT_PAYMENT_GALLERY);
-		}
+		return headers;
 	}
 
 	private String calculateWithoutCoupon(String order, Gallery gallery) {
-		if (Order.TICKET.getValue().equals(order)) {
+		if (OrderType.TICKET.getValue().equals(order)) {
 			return String.valueOf(gallery.getFee());
 		}
 
@@ -211,7 +135,7 @@ public class KakaoPayService {
 	}
 
 	private String calculateWithCoupon(String order, Gallery gallery, int couponValue) {
-		if (Order.TICKET.getValue().equals(order)) {
+		if (OrderType.TICKET.getValue().equals(order)) {
 			return String.valueOf((int)((double)(100 - couponValue) / 100 * gallery.getFee()));
 		}
 
@@ -228,5 +152,40 @@ public class KakaoPayService {
 		return generalCouponWalletRepository
 			.findByMemberIdAndGeneralCouponIdAndIsUsedFalse(memberId, couponId)
 			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_COUPON_NOT_FOUND));
+	}
+
+	private void validateAlreadyPayment(PaymentCreateDto dto, Member member) {
+		if (orderRepository.existsByMemberIdAndGalleryId(member.getId(), dto.galleryId())) {
+			throw new ConflictException(ErrorCode.FAIL_PAYMENT_CONFLICT);
+		}
+	}
+
+	private static void validateOrder(String order) {
+		if (!OrderType.contains(order)) {
+			throw new BadRequestException(ErrorCode.FAIL_INVALID_ORDER);
+		}
+	}
+
+	private void validateExistGallery(PaymentCreateDto dto) {
+		if (dto.order().equals(OrderType.TICKET.getValue()) && !galleryRepository.findIsPaidById(dto.galleryId())) {
+			throw new BadRequestException(ErrorCode.FAIL_NOT_PAYMENT_GALLERY);
+		}
+	}
+
+	private void validateAlreadyTicket(PaymentCreateDto dto, Member member) {
+		if (dto.order().equals(OrderType.TICKET.getValue()) && paymentRepository.existsByMemberAndGalleryIdAndOrderType(
+			member,
+			dto.galleryId(), OrderType.TICKET)) {
+			throw new BadRequestException(ErrorCode.FAIL_ALREADY_PAID_TICKET);
+
+		}
+	}
+
+	private void validateAlreadyGallery(PaymentCreateDto dto, Member member) {
+		if (dto.order().equals(OrderType.PAID_GALLERY.getValue())
+			&& paymentRepository.existsByMemberAndGalleryIdAndOrderType(
+			member, dto.galleryId(), OrderType.PAID_GALLERY)) {
+			throw new BadRequestException(ErrorCode.FAIL_ALREADY_PAID_GALLERY);
+		}
 	}
 }

--- a/src/main/java/com/dart/api/application/payment/PaymentService.java
+++ b/src/main/java/com/dart/api/application/payment/PaymentService.java
@@ -57,13 +57,7 @@ public class PaymentService {
 		validateNotPaymentGallery(order, gallery);
 		validateFree(gallery);
 
-		return OrderReadDto.builder()
-			.title(gallery.getTitle())
-			.thumbnail(gallery.getThumbnail())
-			.nickname(gallery.getMember().getNickname())
-			.profileImage(gallery.getMember().getProfileImageUrl())
-			.cost(calculateCost(order, gallery))
-			.build();
+		return gallery.orderReadDto(calculateCost(order, gallery));
 	}
 
 	private static void validateNotPaymentGallery(String order, Gallery gallery) {

--- a/src/main/java/com/dart/api/application/payment/PaymentService.java
+++ b/src/main/java/com/dart/api/application/payment/PaymentService.java
@@ -13,7 +13,7 @@ import com.dart.api.domain.gallery.entity.Gallery;
 import com.dart.api.domain.gallery.repository.GalleryRepository;
 import com.dart.api.domain.member.entity.Member;
 import com.dart.api.domain.member.repository.MemberRepository;
-import com.dart.api.domain.payment.entity.Order;
+import com.dart.api.domain.payment.entity.OrderType;
 import com.dart.api.domain.payment.entity.Payment;
 import com.dart.api.domain.payment.repository.PaymentRepository;
 import com.dart.api.dto.page.PageInfo;
@@ -67,7 +67,7 @@ public class PaymentService {
 	}
 
 	private static void validateNotPaymentGallery(String order, Gallery gallery) {
-		if (!gallery.isPaid() && Order.TICKET.getValue().equals(order)) {
+		if (!gallery.isPaid() && OrderType.TICKET.getValue().equals(order)) {
 			throw new BadRequestException(ErrorCode.FAIL_NOT_PAYMENT_GALLERY);
 		}
 	}
@@ -85,7 +85,7 @@ public class PaymentService {
 	}
 
 	private int calculateCost(String order, Gallery gallery) {
-		if (Order.TICKET.getValue().equals(order)) {
+		if (OrderType.TICKET.getValue().equals(order)) {
 			return gallery.getFee();
 		}
 
@@ -93,7 +93,7 @@ public class PaymentService {
 	}
 
 	private static void validateOrder(String order) {
-		if (!Order.contains(order)) {
+		if (!OrderType.contains(order)) {
 			throw new BadRequestException(ErrorCode.FAIL_INVALID_ORDER);
 		}
 	}

--- a/src/main/java/com/dart/api/application/payment/PaymentService.java
+++ b/src/main/java/com/dart/api/application/payment/PaymentService.java
@@ -57,7 +57,7 @@ public class PaymentService {
 		validateNotPaymentGallery(order, gallery);
 		validateFree(gallery);
 
-		return gallery.orderReadDto(calculateCost(order, gallery));
+		return gallery.toOrderReadDto(calculateCost(order, gallery));
 	}
 
 	private static void validateNotPaymentGallery(String order, Gallery gallery) {

--- a/src/main/java/com/dart/api/domain/gallery/entity/Gallery.java
+++ b/src/main/java/com/dart/api/domain/gallery/entity/Gallery.java
@@ -109,7 +109,7 @@ public class Gallery extends BaseTimeEntity {
 			.build();
 	}
 
-	public OrderReadDto orderReadDto(int cost) {
+	public OrderReadDto toOrderReadDto(int cost) {
 		return OrderReadDto.builder()
 			.title(this.getTitle())
 			.thumbnail(this.getThumbnail())

--- a/src/main/java/com/dart/api/domain/gallery/entity/Gallery.java
+++ b/src/main/java/com/dart/api/domain/gallery/entity/Gallery.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import com.dart.api.domain.member.entity.Member;
 import com.dart.api.dto.gallery.request.CreateGalleryDto;
 import com.dart.api.dto.gallery.response.GalleryReadIdDto;
+import com.dart.api.dto.payment.response.OrderReadDto;
 import com.dart.global.common.entity.BaseTimeEntity;
 
 import jakarta.persistence.Column;
@@ -105,6 +106,16 @@ public class Gallery extends BaseTimeEntity {
 			.address(createGalleryDto.address())
 			.thumbnail(thumbnailUrl)
 			.member(member)
+			.build();
+	}
+
+	public OrderReadDto orderReadDto(int cost) {
+		return OrderReadDto.builder()
+			.title(this.getTitle())
+			.thumbnail(this.getThumbnail())
+			.nickname(this.getMember().getNickname())
+			.profileImage(this.getMember().getProfileImageUrl())
+			.cost(cost)
 			.build();
 	}
 

--- a/src/main/java/com/dart/api/domain/payment/entity/Order.java
+++ b/src/main/java/com/dart/api/domain/payment/entity/Order.java
@@ -1,30 +1,41 @@
 package com.dart.api.domain.payment.entity;
 
-import java.util.Collections;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 
+@Entity
 @Getter
-@RequiredArgsConstructor
-public enum Order {
-	TICKET("ticket"),
-	PAID_GALLERY("paidGallery");
+@Table(name = "tbl_order")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Order {
+	@Id
+	@Column(name = "id")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-	private final String value;
+	@Column(name = "tid", updatable = false, nullable = false)
+	private String tid;
 
-	private static final Map<String, Order> valuesMap = Collections.unmodifiableMap(Stream.of(values())
-		.collect(Collectors.toMap(Order::getValue, Function.identity())));
+	@Column(name = "member_id", updatable = false, nullable = false)
+	private Long memberId;
 
-	public static Order fromValue(String value) {
-		return valuesMap.get(value);
+	@Column(name = "gallery_id", updatable = false, nullable = false)
+	private Long galleryId;
+
+	private Order(String tid, Long memberId, Long galleryId) {
+		this.tid = tid;
+		this.memberId = memberId;
+		this.galleryId = galleryId;
 	}
 
-	public static boolean contains(String value) {
-		return valuesMap.containsKey(value);
+	public static Order create(String tid, Long memberId, Long galleryId) {
+		return new Order(tid, memberId, galleryId);
 	}
 }

--- a/src/main/java/com/dart/api/domain/payment/entity/Order.java
+++ b/src/main/java/com/dart/api/domain/payment/entity/Order.java
@@ -29,13 +29,21 @@ public class Order {
 	@Column(name = "gallery_id", updatable = false, nullable = false)
 	private Long galleryId;
 
+	@Column(name = "is_approved")
+	private boolean isApproved;
+
 	private Order(String tid, Long memberId, Long galleryId) {
 		this.tid = tid;
 		this.memberId = memberId;
 		this.galleryId = galleryId;
+		this.isApproved = false;
 	}
 
 	public static Order create(String tid, Long memberId, Long galleryId) {
 		return new Order(tid, memberId, galleryId);
+	}
+
+	public void approve() {
+		this.isApproved = true;
 	}
 }

--- a/src/main/java/com/dart/api/domain/payment/entity/OrderType.java
+++ b/src/main/java/com/dart/api/domain/payment/entity/OrderType.java
@@ -1,0 +1,30 @@
+package com.dart.api.domain.payment.entity;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OrderType {
+	TICKET("ticket"),
+	PAID_GALLERY("paidGallery");
+
+	private final String value;
+
+	private static final Map<String, OrderType> valuesMap = Collections.unmodifiableMap(Stream.of(values())
+		.collect(Collectors.toMap(OrderType::getValue, Function.identity())));
+
+	public static OrderType fromValue(String value) {
+		return valuesMap.get(value);
+	}
+
+	public static boolean contains(String value) {
+		return valuesMap.containsKey(value);
+	}
+}

--- a/src/main/java/com/dart/api/domain/payment/entity/Payment.java
+++ b/src/main/java/com/dart/api/domain/payment/entity/Payment.java
@@ -46,7 +46,7 @@ public class Payment {
 
 	@Column(name = "`order`")
 	@Enumerated(EnumType.STRING)
-	private Order order;
+	private OrderType orderType;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id")
@@ -58,14 +58,14 @@ public class Payment {
 		LocalDateTime approvedAt,
 		Member member,
 		Gallery gallery,
-		Order order
+		OrderType orderType
 	) {
 		this.amount = amount;
 		this.approvedAt = approvedAt;
 		this.member = member;
 		this.galleryId = gallery.getId();
 		this.galleryName = gallery.getTitle();
-		this.order = order;
+		this.orderType = orderType;
 	}
 
 	public static Payment create(
@@ -73,13 +73,13 @@ public class Payment {
 		Gallery gallery,
 		int total,
 		LocalDateTime approvedAt,
-		String order
+		String orderType
 	) {
 		return Payment.builder()
 			.member(member)
 			.gallery(gallery)
 			.approvedAt(approvedAt)
-			.order(Order.fromValue(order))
+			.orderType(OrderType.fromValue(orderType))
 			.amount(total)
 			.build();
 	}
@@ -89,7 +89,7 @@ public class Payment {
 			.paymentId(this.id)
 			.amount(this.amount)
 			.approvedAt(this.approvedAt)
-			.order(this.order.getValue())
+			.order(this.orderType.getValue())
 			.galleryName(this.galleryName)
 			.build();
 	}

--- a/src/main/java/com/dart/api/domain/payment/repository/OrderRepository.java
+++ b/src/main/java/com/dart/api/domain/payment/repository/OrderRepository.java
@@ -11,5 +11,5 @@ import com.dart.api.domain.payment.entity.Order;
 public interface OrderRepository extends JpaRepository<Order, Long> {
 	Optional<Order> findByMemberIdAndGalleryId(Long memberId, Long galleryId);
 
-	boolean existsByMemberIdAndGalleryId(Long memberId, Long galleryId);
+	boolean existsByMemberIdAndGalleryIdAndIsApprovedTrue(Long memberId, Long galleryId);
 }

--- a/src/main/java/com/dart/api/domain/payment/repository/OrderRepository.java
+++ b/src/main/java/com/dart/api/domain/payment/repository/OrderRepository.java
@@ -1,0 +1,15 @@
+package com.dart.api.domain.payment.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.dart.api.domain.payment.entity.Order;
+
+@Repository
+public interface OrderRepository extends JpaRepository<Order, Long> {
+	Optional<Order> findByMemberIdAndGalleryId(Long memberId, Long galleryId);
+
+	boolean existsByMemberIdAndGalleryId(Long memberId, Long galleryId);
+}

--- a/src/main/java/com/dart/api/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/dart/api/domain/payment/repository/PaymentRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import com.dart.api.domain.member.entity.Member;
-import com.dart.api.domain.payment.entity.Order;
+import com.dart.api.domain.payment.entity.OrderType;
 import com.dart.api.domain.payment.entity.Payment;
 
 @Repository
@@ -14,5 +14,5 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
 	//결제정보 최근 승인일 순
 	Page<Payment> findAllByMemberOrderByApprovedAtDesc(Member member, Pageable pageable);
 
-	boolean existsByMemberAndGalleryIdAndOrder(Member member, Long galleryId, Order order);
+	boolean existsByMemberAndGalleryIdAndOrderType(Member member, Long galleryId, OrderType orderType);
 }

--- a/src/main/java/com/dart/api/presentation/PaymentController.java
+++ b/src/main/java/com/dart/api/presentation/PaymentController.java
@@ -72,13 +72,8 @@ public class PaymentController {
 		return new RedirectView(SUCCESS_REDIRECT_URL + response + "/" + orderType);
 	}
 
-	@GetMapping("/kakao/cancel/{member-id}/{gallery-id}")
-	public RedirectView cancel(
-		@PathVariable("member-id") Long memberId,
-		@PathVariable("gallery-id") Long galleryId
-	) {
-		kakaoPayApproveService.cancel(memberId, galleryId);
-
+	@GetMapping("/kakao/cancel")
+	public RedirectView cancel() {
 		return new RedirectView(FAIL_REDIRECT_URL);
 	}
 

--- a/src/main/java/com/dart/api/presentation/PaymentController.java
+++ b/src/main/java/com/dart/api/presentation/PaymentController.java
@@ -12,7 +12,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.view.RedirectView;
 
-import com.dart.api.application.payment.KakaoPayService;
+import com.dart.api.application.payment.KakaoPayApproveService;
+import com.dart.api.application.payment.KakaoPayReadyService;
 import com.dart.api.application.payment.PaymentService;
 import com.dart.api.domain.auth.entity.AuthUser;
 import com.dart.api.dto.page.PageResponse;
@@ -30,11 +31,12 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/payment")
 public class PaymentController {
 	private final PaymentService paymentService;
-	private final KakaoPayService kakaoPayService;
+	private final KakaoPayApproveService kakaoPayApproveService;
+	private final KakaoPayReadyService kakaoPayReadyService;
 
 	@PostMapping
 	public PaymentReadyDto ready(@RequestBody @Valid PaymentCreateDto dto, @Auth AuthUser authUser) {
-		return kakaoPayService.ready(dto, authUser);
+		return kakaoPayReadyService.ready(dto, authUser);
 	}
 
 	@GetMapping
@@ -54,21 +56,29 @@ public class PaymentController {
 	) {
 		return paymentService.readOrder(galleryId, order, authUser);
 	}
-	
-	@GetMapping("/kakao/success/{id}/{order}/{coupon-id}/{is-priority}")
+
+	@GetMapping("/kakao/success/{member-id}/{order-type}/{coupon-id}/{is-priority}/{gallery-id}")
 	public RedirectView approve(
 		@RequestParam("pg_token") String token,
-		@PathVariable("id") Long id,
-		@PathVariable("order") String order,
+		@PathVariable("member-id") Long memberId,
+		@PathVariable("order-type") String orderType,
 		@PathVariable("coupon-id") Long couponId,
-		@PathVariable("is-priority") boolean isPriority
+		@PathVariable("is-priority") boolean isPriority,
+		@PathVariable("gallery-id") Long galleryId
 	) {
-		final String galleryId = kakaoPayService.approve(token, id, order, couponId, isPriority);
-		return new RedirectView(SUCCESS_REDIRECT_URL + galleryId + "/" + order);
+		final String response = kakaoPayApproveService.approve(token, memberId, orderType, couponId, isPriority,
+			galleryId);
+
+		return new RedirectView(SUCCESS_REDIRECT_URL + response + "/" + orderType);
 	}
 
-	@GetMapping("/kakao/cancel")
-	public RedirectView cancel() {
+	@GetMapping("/kakao/cancel/{member-id}/{gallery-id}")
+	public RedirectView cancel(
+		@PathVariable("member-id") Long memberId,
+		@PathVariable("gallery-id") Long galleryId
+	) {
+		kakaoPayApproveService.cancel(memberId, galleryId);
+
 		return new RedirectView(FAIL_REDIRECT_URL);
 	}
 

--- a/src/main/java/com/dart/global/common/util/PaymentConstant.java
+++ b/src/main/java/com/dart/global/common/util/PaymentConstant.java
@@ -12,8 +12,6 @@ public class PaymentConstant {
 	public static final String FAIL_URL = "https://dartgallery.site/api/payment/kakao/fail";
 	public static final String SUCCESS_REDIRECT_URL = "https://www.dartgallery.site/payment/success/";
 	public static final String FAIL_REDIRECT_URL = "https://www.dartgallery.site/payment/fail";
-	public static final String PARTNER_USER = "USER";
-	public static final String PARTNER_ORDER = "DART";
 	public static final String TAX = "0";
 	public static final String CID = "TC0ONETIME";
 	public static final String QUANTITY = "1";

--- a/src/main/java/com/dart/global/error/model/ErrorCode.java
+++ b/src/main/java/com/dart/global/error/model/ErrorCode.java
@@ -70,12 +70,14 @@ public enum ErrorCode {
 	FAIL_COUPON_NOT_FOUND("[❎ ERROR] 요청하신 쿠폰을 찾을 수 없습니다."),
 	FAIL_TEMPLATE_NOT_FOUND("[❎ ERROR] 요청하신 템플릿을 찾을 수 없습니다."),
 	FAIL_NOTIFICATION_NOT_FOUND("[❎ ERROR] 요청하신 알림을 찾을 수 없습니다."),
+	FAIL_ORDER_NOT_FOUND("[❎ ERROR] 결제 요청 정보를 찾을 수 없습니다."),
 
 	// 409 Conflict
 	FAIL_EMAIL_CONFLICT("[❎ ERROR] 이미 존재하는 이메일입니다."),
 	FAIL_NICKNAME_CONFLICT("[❎ ERROR] 이미 존재하는 닉네임입니다."),
 	FAIL_GALLERY_CONFLICT_ALREADY_ENDED("[❎ ERROR] 해당 전시회는 이미 종료된 전시회입니다."),
 	FAIL_COUPON_CONFLICT("[❎ ERROR] 이미 쿠폰을 발급 받으셨습니다."),
+	FAIL_PAYMENT_CONFLICT("[❎ ERROR] 이미 결제를 진행하셨습니다."),
 
 	// 500 Server Error
 	FAIL_INTERNAL_SERVER_ERROR("[❎ ERROR] 서버 내부 오류가 발생했습니다. 잠시 후 다시 시도해주세요."),


### PR DESCRIPTION
## 📋 CheckList
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. feat: 유저 조회 기능 구현)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

* close #361 

## 👩‍💻 공유 포인트 및 논의 사항
* 기존 코드는 레이스 컨디션이 발생할 때 동시성 이슈가 발생할 것이라고 판단했습니다.
* 중요한 결제 인증 정보를 담는 Order 테이블로 만들어서, 결제 준비 단계와, 결제 응답 단계에서 Order 객체를 가져와 해결했습니다.
* 결제 정보에 관한 엔티티라 생각했고, 의미 없는 객체 생성을 피하기 위해 연관관계는 짓지 않았습니다.
* 코드 수정으로 인해 결제 준비 단계와, 결제 응답 단계로 서비스를 분리해 주었습니다.
