### PR TITLE
feat: 예외처리를 위한 Security Config 설정 추가

### DIFF
--- a/src/main/java/com/dart/global/auth/filter/AuthenticationFilter.java
+++ b/src/main/java/com/dart/global/auth/filter/AuthenticationFilter.java
@@ -77,8 +77,6 @@ public class AuthenticationFilter extends OncePerRequestFilter {
 				} else if (accessToken == null) {  // 액세스가 없는 경우
 					AuthorizationThreadLocal.setAuthUser(null);
 					filterChain.doFilter(request, response);
-
-					return;
 				} else {  // 액세스 토큰은 들어왔는데 그냥 이상한 경우나 액세스 만료 되었는데 리프레쉬도 이상한경우
 					throw new UnauthorizedException(ErrorCode.FAIL_INVALID_TOKEN);
 				}

--- a/src/main/java/com/dart/global/auth/filter/CustomFilter.java
+++ b/src/main/java/com/dart/global/auth/filter/CustomFilter.java
@@ -1,0 +1,93 @@
+package com.dart.global.auth.filter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.dart.global.error.model.ErrorCode;
+import com.dart.global.error.model.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.constraints.NotNull;
+
+@Component
+@Order(1)
+public class CustomFilter extends OncePerRequestFilter {
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	private static final Map<String, List<String>> VALID_API_PATHS = Map.of(
+		"POST", List.of(
+			"/api/email.*",
+			"/api/events.*",
+			"/api/galleries",
+			"/api/login",
+			"/api/nickname/check",
+			"/api/payment",
+			"/api/reviews",
+			"/api/signup.*"
+		),
+		"GET", List.of(
+			"/api/email.*",
+			"/api/chatroom.*",
+			"/api/chatrooms.*",
+			"/api/events.*",
+			"/api/galleries.*",
+			"/api/mypage.*",
+			"/api/members.*",
+			"/api/members.*",
+			"/api/notifications.*",
+			"/api/nickname/check",
+			"/api/reissue",
+			"/api/reviews.*",
+			"/api/search.*"
+		),
+		"PUT", List.of(
+			"/api/members"
+		),
+		"DELETE", List.of(
+			"/api/galleries"
+		)
+	);
+
+	@Override
+	protected void doFilterInternal(
+		@NotNull HttpServletRequest request,
+		@NotNull HttpServletResponse response,
+		@NotNull FilterChain filterChain)
+		throws ServletException, IOException {
+
+		if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
+			response.setStatus(HttpServletResponse.SC_OK);
+			return;
+		}
+
+		if (!isApiValid(request)) {
+			response.setContentType("application/json;charset=UTF-8");
+			response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+
+			ErrorResponse errorResponse = new ErrorResponse(ErrorCode.FAIL_INVALID_REQUEST.getMessage());
+			String jsonResponse = objectMapper.writeValueAsString(errorResponse);
+
+			response.getWriter().write(jsonResponse);
+			return;
+		}
+
+		filterChain.doFilter(request, response);
+	}
+
+	private boolean isApiValid(HttpServletRequest request) {
+		String path = request.getRequestURI();
+		String method = request.getMethod();
+		return VALID_API_PATHS.getOrDefault(method, List.of()).stream()
+			.anyMatch(validPath -> path.matches(validPath.replace("**", ".*")));
+	}
+}

--- a/src/main/java/com/dart/global/auth/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/dart/global/auth/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,33 @@
+package com.dart.global.auth.handler;
+
+import java.io.IOException;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import com.dart.global.error.model.ErrorCode;
+import com.dart.global.error.model.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException authException) throws IOException, ServletException {
+		response.setContentType("application/json;charset=UTF-8");
+		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+		ErrorResponse errorResponse = new ErrorResponse(ErrorCode.FAIL_LOGIN_REQUIRED.getMessage());
+		String jsonResponse = objectMapper.writeValueAsString(errorResponse);
+
+		response.getWriter().write(jsonResponse);
+	}
+}

--- a/src/main/java/com/dart/global/auth/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/dart/global/auth/handler/CustomAuthenticationEntryPoint.java
@@ -21,7 +21,7 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
 
 	@Override
 	public void commence(HttpServletRequest request, HttpServletResponse response,
-		AuthenticationException authException) throws IOException, ServletException {
+		AuthenticationException authException) throws IOException {
 		response.setContentType("application/json;charset=UTF-8");
 		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 

--- a/src/main/java/com/dart/global/config/SecurityConfig.java
+++ b/src/main/java/com/dart/global/config/SecurityConfig.java
@@ -7,33 +7,39 @@ import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 
 import com.dart.api.application.auth.JwtProviderService;
 import com.dart.global.auth.filter.AuthenticationFilter;
+import com.dart.global.auth.filter.CustomFilter;
+import com.dart.global.auth.handler.CustomAuthenticationEntryPoint;
+import com.dart.global.common.util.CookieUtil;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
 
+	private final CookieUtil cookieUtil;
 	private final JwtProviderService jwtProviderService;
 	private final HandlerExceptionResolver handlerExceptionResolver;
+	private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
 	public SecurityConfig(
-		JwtProviderService jwtProviderService,
-		@Qualifier("handlerExceptionResolver") HandlerExceptionResolver handlerExceptionResolver
+		CookieUtil cookieUtil, JwtProviderService jwtProviderService,
+		@Qualifier("handlerExceptionResolver") HandlerExceptionResolver handlerExceptionResolver,
+		CustomAuthenticationEntryPoint customAuthenticationEntryPoint
 	) {
+		this.cookieUtil = cookieUtil;
 		this.jwtProviderService = jwtProviderService;
 		this.handlerExceptionResolver = handlerExceptionResolver;
+		this.customAuthenticationEntryPoint = customAuthenticationEntryPoint;
 	}
 
 	@Bean
@@ -58,7 +64,8 @@ public class SecurityConfig {
 			.httpBasic(AbstractHttpConfigurer::disable)
 			.sessionManagement(session -> session.sessionCreationPolicy(STATELESS));
 
-		httpSecurity.authorizeHttpRequests((auth) -> auth
+		httpSecurity
+			.authorizeHttpRequests((auth) -> auth
 			.requestMatchers("/favicon.ico").permitAll()
 			.requestMatchers("/ws/**").permitAll()
 			.requestMatchers(HttpMethod.GET, "/api/signup/*").permitAll()
@@ -74,14 +81,13 @@ public class SecurityConfig {
 			.anyRequest().authenticated()
 		);
 
-		httpSecurity.addFilterBefore(
-			new AuthenticationFilter(jwtProviderService, handlerExceptionResolver),
-			UsernamePasswordAuthenticationFilter.class
-		);
+		httpSecurity
+			.addFilterBefore(new CustomFilter(), UsernamePasswordAuthenticationFilter.class)
+			.addFilterBefore(new AuthenticationFilter(cookieUtil, jwtProviderService, handlerExceptionResolver),
+				UsernamePasswordAuthenticationFilter.class);
 
 		httpSecurity.exceptionHandling((exceptionHandling) -> {
-			HttpStatusEntryPoint httpStatusEntryPoint = new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED);
-			exceptionHandling.authenticationEntryPoint(httpStatusEntryPoint);
+			exceptionHandling.authenticationEntryPoint(customAuthenticationEntryPoint);
 		});
 
 		return httpSecurity.build();

--- a/src/main/java/com/dart/global/error/model/ErrorCode.java
+++ b/src/main/java/com/dart/global/error/model/ErrorCode.java
@@ -47,8 +47,8 @@ public enum ErrorCode {
 
 	// 401 Unauthorized
 	FAIL_LOGIN_REQUIRED("[❎ ERROR] 로그인이 필요한 기능입니다."),
-	FAIL_TOKEN_EXPIRED("[❎ ERROR] 인증 토큰이 만료되었습니다. 다시 로그인해 주세요."),
-	FAIL_INVALID_TOKEN("[❎ ERROR] 유효하지 않은 인증 토큰입니다. 다시 로그인해 주세요."),
+	FAIL_TOKEN_EXPIRED("[❎ ERROR] 인증 토큰이 만료되었습니다."),
+	FAIL_INVALID_TOKEN("[❎ ERROR] 유효하지 않은 인증 토큰입니다."),
 	FAIL_TOKEN_MISMATCH("[❎ ERROR] 토큰 소유자가 일치하지 않습니다."),
 	FAIL_INVALID_EMAIL_CODE("[❎ ERROR] 인증 코드가 만료되었습니다. 이메일 중복확인을 다시 시도해 주세요."),
 


### PR DESCRIPTION
## 📋 CheckList
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. feat: 유저 조회 기능 구현)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 #374<!-- 이슈 번호를 작성해주세요 ex) #11 -->

* close #374

## 👩‍💻 공유 포인트 및 논의 사항
* 배경
** 메소드 내에서 처리된 예외 외에 모든 예외가 401 상태코드가 반환이 되었습니다.

* 해결
** 잘못된 API 요청에 대해서 404 상태코드를 반환하도록 하였습니다.
** 로그인이 필요한 API 요청에 대하여 401 상태코드를 반환하도록 하였습니다.

* 개발
** CustomFilter에 API 및 요청방식을 추가하였으며, 잘못된 API 요청을 처리하였습니다.
** CustomAuthenticationEntryPoint를 통해, 로그인이 필요한 API 요청을 처리하였습니다.
** Spring Security 설정에 적용하였습니다.