### PR TITLE
refactor: 채팅메시지 목록 조회 서비스 분리 및 변경된 사용자 정보가 반영되도록 수정

### DIFF
--- a/src/main/java/com/dart/api/application/chat/ChatMessageReadService.java
+++ b/src/main/java/com/dart/api/application/chat/ChatMessageReadService.java
@@ -52,7 +52,7 @@ public class ChatMessageReadService {
 		return createPageResponse(chatMessageReadDtoList, page, size);
 	}
 
-	private List<ChatMessageReadDto> fetchChatMessagesFromDBAndUpdateMembers(Long chatRoomId, int page, int size) {
+	public List<ChatMessageReadDto> fetchChatMessagesFromDBAndUpdateMembers(Long chatRoomId, int page, int size) {
 		final ChatRoom chatRoom = getChatRoomById(chatRoomId);
 		final Pageable pageable = PageRequest.of(page, size);
 		final Page<ChatMessage> mySQLChatMessages = chatMessageRepository.findByChatRoomOrderByCreatedAtDesc(
@@ -70,7 +70,7 @@ public class ChatMessageReadService {
 		return updatedChatMessageReadDtoList;
 	}
 
-	private List<ChatMessageReadDto> updateMembersInChatMessages(List<ChatMessageReadDto> chatMessageReadDtoList) {
+	public List<ChatMessageReadDto> updateMembersInChatMessages(List<ChatMessageReadDto> chatMessageReadDtoList) {
 		final List<String> emailList = chatMessageReadDtoList.stream()
 			.map(ChatMessageReadDto::sender)
 			.distinct()

--- a/src/main/java/com/dart/api/application/chat/ChatMessageReadService.java
+++ b/src/main/java/com/dart/api/application/chat/ChatMessageReadService.java
@@ -1,0 +1,132 @@
+package com.dart.api.application.chat;
+
+import static com.dart.global.common.util.ChatConstant.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.dart.api.domain.chat.entity.ChatMessage;
+import com.dart.api.domain.chat.entity.ChatRoom;
+import com.dart.api.domain.chat.repository.ChatMessageRepository;
+import com.dart.api.domain.chat.repository.ChatRedisRepository;
+import com.dart.api.domain.chat.repository.ChatRoomRepository;
+import com.dart.api.domain.member.entity.Member;
+import com.dart.api.domain.member.repository.MemberRepository;
+import com.dart.api.dto.chat.request.ChatMessageSendDto;
+import com.dart.api.dto.chat.response.ChatMessageReadDto;
+import com.dart.api.dto.page.PageInfo;
+import com.dart.api.dto.page.PageResponse;
+import com.dart.global.error.exception.NotFoundException;
+import com.dart.global.error.model.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ChatMessageReadService {
+
+	private final ChatRoomRepository chatRoomRepository;
+	private final MemberRepository memberRepository;
+	private final ChatRedisRepository chatRedisRepository;
+	private final ChatMessageRepository chatMessageRepository;
+
+	@Transactional(readOnly = true)
+	public PageResponse<ChatMessageReadDto> getChatMessageList(Long chatRoomId, int page, int size) {
+		final PageResponse<ChatMessageReadDto> redisChatMessageReadDtoList =
+			chatRedisRepository.getChatMessageReadDto(chatRoomId, page, size);
+
+		if (redisChatMessageReadDtoList != null && !redisChatMessageReadDtoList.pages().isEmpty()) {
+			return createPageResponse(new ArrayList<>(redisChatMessageReadDtoList.pages()), page, size);
+		}
+
+		final List<ChatMessageReadDto> chatMessageReadDtoList =
+			fetchChatMessagesFromDBAndUpdateMembers(chatRoomId, page, size);
+		return createPageResponse(chatMessageReadDtoList, page, size);
+	}
+
+	private List<ChatMessageReadDto> fetchChatMessagesFromDBAndUpdateMembers(Long chatRoomId, int page, int size) {
+		final ChatRoom chatRoom = getChatRoomById(chatRoomId);
+		final Pageable pageable = PageRequest.of(page, size);
+		final Page<ChatMessage> mySQLChatMessages = chatMessageRepository.findByChatRoomOrderByCreatedAtDesc(
+			chatRoom, pageable);
+
+		final List<ChatMessageReadDto> mySQLChatMessageReadDtoList = mySQLChatMessages.stream()
+			.map(ChatMessage::toChatMessageReadDto)
+			.toList();
+
+		final List<ChatMessageReadDto> updatedChatMessageReadDtoList = updateMembersInChatMessages(
+			mySQLChatMessageReadDtoList);
+
+		cachingChatMessages(chatRoom, mySQLChatMessageReadDtoList);
+
+		return updatedChatMessageReadDtoList;
+	}
+
+	private List<ChatMessageReadDto> updateMembersInChatMessages(List<ChatMessageReadDto> chatMessageReadDtoList) {
+		final List<String> emailList = chatMessageReadDtoList.stream()
+			.map(ChatMessageReadDto::sender)
+			.distinct()
+			.toList();
+
+		final List<Member> memberList = memberRepository.findByEmailIn(emailList);
+
+		final Map<String, Member> memberMap = memberList.stream()
+			.collect(Collectors.toMap(Member::getEmail, member -> member));
+
+		return chatMessageReadDtoList.stream()
+			.map(chatMessageReadDto -> updateChatMessageReadDtoWithMember(
+				chatMessageReadDto, memberMap.get(chatMessageReadDto.sender())))
+			.toList();
+	}
+
+	private ChatMessageReadDto updateChatMessageReadDtoWithMember(ChatMessageReadDto chatMessageReadDto,
+		Member member
+	) {
+		if (member != null) {
+			return createChatMessageReadDto(chatMessageReadDto, member);
+		}
+		return chatMessageReadDto;
+	}
+
+	private ChatMessageReadDto createChatMessageReadDto(ChatMessageReadDto chatMessageReadDto, Member member) {
+		return new ChatMessageReadDto(member.getNickname(), chatMessageReadDto.content(),
+			chatMessageReadDto.createdAt(), chatMessageReadDto.isAuthor(), member.getProfileImageUrl());
+	}
+
+	private void cachingChatMessages(ChatRoom chatRoom, List<ChatMessageReadDto> chatMessageReadDtoList) {
+		chatMessageReadDtoList.forEach(chatMessages -> {
+			final Member member = getMemberByNickname(chatMessages.sender());
+			final ChatMessage chatMessage = ChatMessage.chatMessageFromReadDto(chatRoom, member, chatMessages);
+			final ChatMessageSendDto chatMessageSendDto = chatMessage.toChatMessageSendDto(CHAT_MESSAGE_EXPIRY_SECONDS);
+
+			chatRedisRepository.saveChatMessage(chatMessageSendDto, member);
+		});
+	}
+
+	private ChatRoom getChatRoomById(Long chatRoomId) {
+		return chatRoomRepository.findById(chatRoomId)
+			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_CHAT_ROOM_NOT_FOUND));
+	}
+
+	private Member getMemberByNickname(String nickname) {
+		return memberRepository.findByNickname(nickname)
+			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_MEMBER_NOT_FOUND));
+	}
+
+	private PageResponse<ChatMessageReadDto> createPageResponse(List<ChatMessageReadDto> chatMessageReadDtoList,
+		int page, int size
+	) {
+		final boolean isDone = chatMessageReadDtoList.size() < size;
+		final PageInfo pageInfo = new PageInfo(page, isDone);
+
+		return new PageResponse<>(chatMessageReadDtoList, pageInfo);
+	}
+}

--- a/src/main/java/com/dart/api/application/chat/ChatMessageService.java
+++ b/src/main/java/com/dart/api/application/chat/ChatMessageService.java
@@ -2,12 +2,6 @@ package com.dart.api.application.chat;
 
 import static com.dart.global.common.util.ChatConstant.*;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,9 +14,6 @@ import com.dart.api.domain.member.entity.Member;
 import com.dart.api.domain.member.repository.MemberRepository;
 import com.dart.api.dto.chat.request.ChatMessageCreateDto;
 import com.dart.api.dto.chat.request.ChatMessageSendDto;
-import com.dart.api.dto.chat.response.ChatMessageReadDto;
-import com.dart.api.dto.page.PageInfo;
-import com.dart.api.dto.page.PageResponse;
 import com.dart.global.error.exception.NotFoundException;
 import com.dart.global.error.model.ErrorCode;
 
@@ -48,19 +39,6 @@ public class ChatMessageService {
 		chatRedisRepository.saveChatMessage(chatMessageSendDto, member);
 	}
 
-	@Transactional(readOnly = true)
-	public PageResponse<ChatMessageReadDto> getChatMessageList(Long chatRoomId, int page, int size) {
-		final PageResponse<ChatMessageReadDto> redisChatMessageReadDtoList = chatRedisRepository.getChatMessageReadDto(
-			chatRoomId, page, size);
-
-		if (redisChatMessageReadDtoList != null && !redisChatMessageReadDtoList.pages().isEmpty()) {
-			return createPageResponse(new ArrayList<>(redisChatMessageReadDtoList.pages()), page, size);
-		}
-
-		final List<ChatMessageReadDto> chatMessageReadDtoList = fetchChatMessagesFromDBAndCache(chatRoomId, page, size);
-		return createPageResponse(chatMessageReadDtoList, page, size);
-	}
-
 	private ChatRoom getChatRoomById(Long chatRoomId) {
 		return chatRoomRepository.findById(chatRoomId)
 			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_CHAT_ROOM_NOT_FOUND));
@@ -69,38 +47,5 @@ public class ChatMessageService {
 	private Member getMemberByNickname(String nickname) {
 		return memberRepository.findByNickname(nickname)
 			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_MEMBER_NOT_FOUND));
-	}
-
-	private List<ChatMessageReadDto> fetchChatMessagesFromDBAndCache(Long chatRoomId, int page, int size) {
-		final ChatRoom chatRoom = getChatRoomById(chatRoomId);
-		final Pageable pageable = PageRequest.of(page, size);
-		final Page<ChatMessage> mySQLChatMessages =
-			chatMessageRepository.findByChatRoomOrderByCreatedAtDesc(chatRoom, pageable);
-
-		final List<ChatMessageReadDto> mySQLChatMessageReadDtoList = mySQLChatMessages.stream()
-			.map(ChatMessage::toChatMessageReadDto)
-			.toList();
-
-		cachingChatMessages(chatRoom, mySQLChatMessageReadDtoList);
-
-		return mySQLChatMessageReadDtoList;
-	}
-
-	private void cachingChatMessages(ChatRoom chatRoom, List<ChatMessageReadDto> chatMessageReadDtoList) {
-		chatMessageReadDtoList.forEach(chatMessages -> {
-			final Member member = getMemberByNickname(chatMessages.sender());
-			final ChatMessage chatMessage = ChatMessage.chatMessageFromReadDto(chatRoom, member, chatMessages);
-			final ChatMessageSendDto chatMessageSendDto = chatMessage.toChatMessageSendDto(CHAT_MESSAGE_EXPIRY_SECONDS);
-
-			chatRedisRepository.saveChatMessage(chatMessageSendDto, member);
-		});
-	}
-
-	private PageResponse<ChatMessageReadDto> createPageResponse(List<ChatMessageReadDto> chatMessageReadDtoList,
-		int page, int size) {
-		final boolean isDone = chatMessageReadDtoList.size() < size;
-		final PageInfo pageInfo = new PageInfo(page, isDone);
-
-		return new PageResponse<>(chatMessageReadDtoList, pageInfo);
 	}
 }

--- a/src/main/java/com/dart/api/domain/chat/repository/ChatRedisRepository.java
+++ b/src/main/java/com/dart/api/domain/chat/repository/ChatRedisRepository.java
@@ -72,9 +72,9 @@ public class ChatRedisRepository {
 		try {
 			return objectMapper.readValue(messageValue.toString(), ChatMessageReadDto.class);
 		} catch (JsonMappingException e) {
-			throw new RuntimeException("Failed to map JSON to ChatMessageReadDto", e);
+			throw new RuntimeException("[✅ LOGGER] FAILED TO MAP JSON TO CHAT MESSAGE READ DTO", e);
 		} catch (JsonProcessingException e) {
-			throw new RuntimeException("Failed to process JSON", e);
+			throw new RuntimeException("[✅ LOGGER] FAILED TO PROCESS JSON", e);
 		}
 	}
 }

--- a/src/main/java/com/dart/api/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/dart/api/domain/member/repository/MemberRepository.java
@@ -1,5 +1,6 @@
 package com.dart.api.domain.member.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,5 +12,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 	boolean existsByNickname(String nickname);
 	Optional<Member> findByEmail(String email);
 	Optional<Member> findByNickname(String nickname);
+	List<Member> findByEmailIn(List<String> emailList);
 
 }

--- a/src/main/java/com/dart/api/presentation/ChatController.java
+++ b/src/main/java/com/dart/api/presentation/ChatController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.dart.api.application.chat.ChatMessageReadService;
 import com.dart.api.application.chat.ChatMessageService;
 import com.dart.api.dto.chat.request.ChatMessageCreateDto;
 import com.dart.api.dto.chat.response.ChatMessageReadDto;
@@ -29,8 +30,9 @@ import lombok.RequiredArgsConstructor;
 public class ChatController {
 
 	private final SimpMessageSendingOperations simpMessageSendingOperations;
-	private final ChatMessageService chatMessageService;
 	private final MemberSessionRegistry memberSessionRegistry;
+	private final ChatMessageService chatMessageService;
+	private final ChatMessageReadService chatMessageReadService;
 
 	@MessageMapping(value = "/ws/{chat-room-id}/chat-messages")
 	public void saveAndSendChatMessage(
@@ -47,7 +49,7 @@ public class ChatController {
 		@RequestParam(defaultValue = "0") int page,
 		@RequestParam(defaultValue = "99") int size
 	) {
-		return ResponseEntity.ok(chatMessageService.getChatMessageList(chatRoomId, page, size));
+		return ResponseEntity.ok(chatMessageReadService.getChatMessageList(chatRoomId, page, size));
 	}
 
 	@GetMapping("/api/chat-rooms/{chat-room-id}/members")

--- a/src/test/java/com/dart/api/application/chat/ChatMessageReadServiceTest.java
+++ b/src/test/java/com/dart/api/application/chat/ChatMessageReadServiceTest.java
@@ -1,0 +1,221 @@
+package com.dart.api.application.chat;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.anyList;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import com.dart.api.domain.chat.entity.ChatMessage;
+import com.dart.api.domain.chat.entity.ChatRoom;
+import com.dart.api.domain.chat.repository.ChatMessageRepository;
+import com.dart.api.domain.chat.repository.ChatRedisRepository;
+import com.dart.api.domain.chat.repository.ChatRoomRepository;
+import com.dart.api.domain.member.entity.Member;
+import com.dart.api.domain.member.repository.MemberRepository;
+import com.dart.api.dto.chat.request.ChatMessageCreateDto;
+import com.dart.api.dto.chat.response.ChatMessageReadDto;
+import com.dart.api.dto.page.PageInfo;
+import com.dart.api.dto.page.PageResponse;
+import com.dart.global.error.exception.NotFoundException;
+import com.dart.support.ChatFixture;
+import com.dart.support.MemberFixture;
+
+@ExtendWith(MockitoExtension.class)
+class ChatMessageReadServiceTest {
+
+	@Mock
+	private ChatRoomRepository chatRoomRepository;
+
+	@Mock
+	private MemberRepository memberRepository;
+
+	@Mock
+	private ChatRedisRepository chatRedisRepository;
+
+	@Mock
+	private ChatMessageRepository chatMessageRepository;
+
+	@InjectMocks
+	private ChatMessageReadService chatMessageReadService;
+
+	@Test
+	@DisplayName("GET CHAT MESSAGE LIST(⭕️ SUCCESS): 성공적으로 채팅 메시지 목록을 조회했습니다.")
+	void getChatMessageList_void_success() {
+		// GIVEN
+		Long chatRoomId = 1L;
+		int page = 0;
+		int size = 10;
+
+		List<ChatMessageReadDto> chatMessages = Arrays.asList(
+			new ChatMessageReadDto("member1", "Hello 👋🏻", LocalDateTime.now(), true,
+				"https://example.com/profile1.jpg"),
+			new ChatMessageReadDto("member2", "Bye 👋🏻", LocalDateTime.now(), true, "https://example.com/profile2.jpg")
+		);
+		PageResponse<ChatMessageReadDto> pageResponse = new PageResponse<>(chatMessages, new PageInfo(page, true));
+
+		when(chatRedisRepository.getChatMessageReadDto(chatRoomId, page, size)).thenReturn(pageResponse);
+
+		// WHEN
+		PageResponse<ChatMessageReadDto> actualPageResponse = chatMessageReadService.getChatMessageList(
+			chatRoomId, page, size
+		);
+
+		// THEN
+		assertThat(actualPageResponse).isEqualTo(pageResponse);
+		verify(chatRedisRepository, times(1)).getChatMessageReadDto(chatRoomId, page, size);
+	}
+
+	@Test
+	@DisplayName("GET CHAT MESSAGE LIST FROM DB(⭕️ SUCCESS): Redis에 없는 경우 DB에서 채팅 메시지 목록을 조회했습니다.")
+	void getChatMessageList_fromDb_success() {
+		// GIVEN
+		Long chatRoomId = 1L;
+		int page = 0;
+		int size = 10;
+
+		ChatRoom chatRoom = ChatFixture.createChatRoomEntity();
+		Member member1 = MemberFixture.createMemberEntityWithEmailAndNickname("member1@example.com", "member1");
+		Member member2 = MemberFixture.createMemberEntityWithEmailAndNickname("member2@example.com", "member2");
+
+		ChatMessageCreateDto chatMessageCreateDto1 = ChatFixture.createChatMessageEntityForChatMessageCreateDto();
+		ChatMessageCreateDto chatMessageCreateDto2 = ChatFixture.createChatMessageEntityForChatMessageCreateDto();
+
+		List<ChatMessage> chatMessageList = Arrays.asList(
+			ChatFixture.createChatMessageEntity(chatRoom, member1, chatMessageCreateDto1),
+			ChatFixture.createChatMessageEntity(chatRoom, member2, chatMessageCreateDto2)
+		);
+		Page<ChatMessage> chatMessagePage = new PageImpl<>(chatMessageList);
+
+		List<ChatMessageReadDto> chatMessages = chatMessageList.stream()
+			.map(ChatMessage::toChatMessageReadDto)
+			.collect(Collectors.toList());
+		PageResponse<ChatMessageReadDto> expectedPageResponse = new PageResponse<>(chatMessages,
+			new PageInfo(page, true));
+
+		when(chatRedisRepository.getChatMessageReadDto(chatRoomId, page, size)).thenReturn(null);
+		when(chatRoomRepository.findById(chatRoomId)).thenReturn(Optional.of(chatRoom));
+		when(chatMessageRepository.findByChatRoomOrderByCreatedAtDesc(any(ChatRoom.class), any(Pageable.class)))
+			.thenReturn(chatMessagePage);
+		when(memberRepository.findByEmailIn(anyList())).thenReturn(Arrays.asList(member1, member2));
+		when(memberRepository.findByNickname(member1.getNickname())).thenReturn(Optional.of(member1));
+		when(memberRepository.findByNickname(member2.getNickname())).thenReturn(Optional.of(member2));
+
+		// WHEN
+		PageResponse<ChatMessageReadDto> actualPageResponse = chatMessageReadService.getChatMessageList(
+			chatRoomId, page, size
+		);
+
+		// THEN
+		assertThat(actualPageResponse).isEqualTo(expectedPageResponse);
+		verify(chatRedisRepository, times(1)).getChatMessageReadDto(chatRoomId, page, size);
+		verify(chatRoomRepository, times(1)).findById(chatRoomId);
+		verify(chatMessageRepository, times(1)).findByChatRoomOrderByCreatedAtDesc(any(ChatRoom.class),
+			any(Pageable.class));
+	}
+
+	@Test
+	@DisplayName("GET CHAT MESSAGE LIST(❌ FAILURE): 존재하지 않은 채팅방의 채팅 메시지 목록을 조회했습니다.")
+	void getChatMessageList_NotFoundException_fail() {
+		// GIVEN
+		Long chatRoomId = 1L;
+		int page = 0;
+		int size = 10;
+
+		when(chatRedisRepository.getChatMessageReadDto(chatRoomId, page, size)).thenReturn(null);
+		when(chatRoomRepository.findById(chatRoomId)).thenReturn(Optional.empty());
+
+		// WHEN & THEN
+		assertThatThrownBy(() -> chatMessageReadService.getChatMessageList(chatRoomId, page, size))
+			.isInstanceOf(NotFoundException.class)
+			.hasMessage("[❎ ERROR] 요청하신 채팅방을 찾을 수 없습니다.");
+	}
+
+	@Test
+	@DisplayName("FETCH CHAT MESSAGES FROM DB AND UPDATE MEMBERS(⭕️ SUCCESS): DB에서 채팅 메시지를 조회하고 회원 정보를 업데이트했습니다.")
+	void fetchChatMessagesFromDBAndUpdateMembers_void_success() {
+		// GIVEN
+		Long chatRoomId = 1L;
+		int page = 0;
+		int size = 10;
+
+		ChatRoom chatRoom = ChatFixture.createChatRoomEntity();
+		Member member1 = MemberFixture.createMemberEntityWithEmailAndNickname("member1@example.com", "member1");
+		Member member2 = MemberFixture.createMemberEntityWithEmailAndNickname("member2@example.com", "member2");
+
+		ChatMessageCreateDto chatMessageCreateDto1 = ChatFixture.createChatMessageEntityForChatMessageCreateDto();
+		ChatMessageCreateDto chatMessageCreateDto2 = ChatFixture.createChatMessageEntityForChatMessageCreateDto();
+
+		List<ChatMessage> chatMessageList = Arrays.asList(
+			ChatFixture.createChatMessageEntity(chatRoom, member1, chatMessageCreateDto1),
+			ChatFixture.createChatMessageEntity(chatRoom, member2, chatMessageCreateDto2)
+		);
+		Page<ChatMessage> chatMessagePage = new PageImpl<>(chatMessageList);
+
+		when(chatRoomRepository.findById(chatRoomId)).thenReturn(Optional.of(chatRoom));
+		when(chatMessageRepository.findByChatRoomOrderByCreatedAtDesc(any(ChatRoom.class), any(Pageable.class)))
+			.thenReturn(chatMessagePage);
+		when(memberRepository.findByEmailIn(anyList())).thenReturn(Arrays.asList(member1, member2));
+		when(memberRepository.findByNickname(member1.getNickname())).thenReturn(Optional.of(member1));
+		when(memberRepository.findByNickname(member2.getNickname())).thenReturn(Optional.of(member2));
+
+		// WHEN
+		List<ChatMessageReadDto> actualChatMessageReadDtoList =
+			chatMessageReadService.fetchChatMessagesFromDBAndUpdateMembers(chatRoomId, page, size);
+
+		// THEN
+		assertThat(actualChatMessageReadDtoList).hasSize(2);
+		assertThat(actualChatMessageReadDtoList.get(0).sender()).isEqualTo(member1.getNickname());
+		assertThat(actualChatMessageReadDtoList.get(0).profileImageUrl()).isEqualTo(member1.getProfileImageUrl());
+		assertThat(actualChatMessageReadDtoList.get(1).sender()).isEqualTo(member2.getNickname());
+		assertThat(actualChatMessageReadDtoList.get(1).profileImageUrl()).isEqualTo(member2.getProfileImageUrl());
+
+		verify(chatRoomRepository, times(1)).findById(chatRoomId);
+		verify(chatMessageRepository, times(1)).findByChatRoomOrderByCreatedAtDesc(
+			any(ChatRoom.class), any(Pageable.class));
+		verify(memberRepository, times(1)).findByEmailIn(anyList());
+		verify(memberRepository, times(2)).findByNickname(anyString());
+	}
+
+	@Test
+	@DisplayName("UPDATE MEMBERS IN CHAT MESSAGES(⭕️ SUCCESS): 채팅 메시지 목록의 회원 정보를 성공적으로 업데이트했습니다.")
+	void updateMembersInChatMessages_void_success() {
+		// GIVEN
+		List<ChatMessageReadDto> chatMessages = Arrays.asList(
+			new ChatMessageReadDto("member1", "Hello 👋🏻", LocalDateTime.now(), true, null),
+			new ChatMessageReadDto("member2", "Bye 👋🏻", LocalDateTime.now(), true, null)
+		);
+		Member member1 = MemberFixture.createMemberEntityWithEmailAndNickname("member1@example.com", "member1");
+		Member member2 = MemberFixture.createMemberEntityWithEmailAndNickname("member2@example.com", "member2");
+		List<Member> memberList = Arrays.asList(member1, member2);
+
+		when(memberRepository.findByEmailIn(anyList())).thenReturn(memberList);
+
+		// WHEN
+		List<ChatMessageReadDto> actualChatMessageReadDtoList =
+			chatMessageReadService.updateMembersInChatMessages(chatMessages);
+
+		// THEN
+		assertThat(actualChatMessageReadDtoList).hasSize(2);
+		assertThat(actualChatMessageReadDtoList.get(0).sender()).isEqualTo(member1.getNickname());
+		assertThat(actualChatMessageReadDtoList.get(0).profileImageUrl()).isEqualTo(member1.getProfileImageUrl());
+		assertThat(actualChatMessageReadDtoList.get(1).sender()).isEqualTo(member2.getNickname());
+		assertThat(actualChatMessageReadDtoList.get(1).profileImageUrl()).isEqualTo(member2.getProfileImageUrl());
+		verify(memberRepository, times(1)).findByEmailIn(anyList());
+	}
+}

--- a/src/test/java/com/dart/api/infrastructure/websocket/AuthChannelInterceptorTest.java
+++ b/src/test/java/com/dart/api/infrastructure/websocket/AuthChannelInterceptorTest.java
@@ -83,7 +83,7 @@ class AuthChannelInterceptorTest {
 		// WHEN & THEN
 		assertThatThrownBy(() -> authChannelInterceptor.preSend(message, messageChannel))
 			.isInstanceOf(NotFoundException.class)
-			.hasMessage("[❎ ERROR] 유효하지 않은 인증 토큰입니다. 다시 로그인해 주세요.");
+			.hasMessage("[❎ ERROR] 유효하지 않은 인증 토큰입니다.");
 
 		verify(jwtProviderService, times(1)).isUsable(anyString());
 		verify(jwtProviderService, never()).extractAuthUserByAccessToken(anyString());

--- a/src/test/java/com/dart/api/infrastructure/websocket/WebSocketErrorHandlerTest.java
+++ b/src/test/java/com/dart/api/infrastructure/websocket/WebSocketErrorHandlerTest.java
@@ -47,7 +47,7 @@ class WebSocketErrorHandlerTest {
 		StompHeaderAccessor stompHeaderAccessor = StompHeaderAccessor.wrap(errorMessage);
 		assertEquals(StompCommand.ERROR, stompHeaderAccessor.getCommand());
 		assertEquals(
-			"[❎ ERROR] 인증 토큰이 만료되었습니다. 다시 로그인해 주세요.",
+			"[❎ ERROR] 인증 토큰이 만료되었습니다.",
 			new String(errorMessage.getPayload(), StandardCharsets.UTF_8));
 	}
 
@@ -87,7 +87,7 @@ class WebSocketErrorHandlerTest {
 		StompHeaderAccessor accessor = StompHeaderAccessor.wrap(errorMessage);
 		assertEquals(StompCommand.ERROR, accessor.getCommand());
 		assertEquals(
-			"[❎ ERROR] 유효하지 않은 인증 토큰입니다. 다시 로그인해 주세요.",
+			"[❎ ERROR] 유효하지 않은 인증 토큰입니다.",
 			new String(errorMessage.getPayload(), StandardCharsets.UTF_8));
 	}
 

--- a/src/test/java/com/dart/support/MemberFixture.java
+++ b/src/test/java/com/dart/support/MemberFixture.java
@@ -14,6 +14,13 @@ public class MemberFixture {
 		);
 	}
 
+	public static Member createMemberEntityWithEmailAndNickname(String email, String nickname) {
+		return Member.signup(
+			createSignUpDto(email, nickname),
+			"1q2w3e4r!"
+		);
+	}
+
 	public static SignUpDto createSignUpDto(String email, String nickname) {
 		return SignUpDto.builder()
 			.email(email)


### PR DESCRIPTION
## 📋 CheckList
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. feat: 유저 조회 기능 구현)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

* close #390 

## 👩‍💻 공유 포인트 및 논의 사항
* 채팅 메시지 목록 서비스 로직을 분리했습니다.
* 변경된 사용자 정보가 채팅 메시지가 반영되도록 수정했고, 일괄 조회를 하도록 구현했습니다.
* 관련된 테스트 코드를 작성 및 수정했습니다.
