### PR TITLE
feat: 지난 이벤트 알림을 받는 로직 구현

### DIFF
--- a/src/main/java/com/dart/api/application/notification/CouponNotificationService.java
+++ b/src/main/java/com/dart/api/application/notification/CouponNotificationService.java
@@ -42,8 +42,7 @@ public class CouponNotificationService {
 	}
 
 	private List<PriorityCoupon> getTodayCoupons() {
-		LocalDate startedAt = LocalDate.now();
-		return priorityCouponRepository.findByStartedAt(startedAt);
+		return priorityCouponRepository.findByStartedAt(LocalDate.now());
 	}
 
 	private void notifyAllClientsAboutNewCoupons() {

--- a/src/main/java/com/dart/api/application/notification/SSENotificationService.java
+++ b/src/main/java/com/dart/api/application/notification/SSENotificationService.java
@@ -8,6 +8,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import com.dart.api.domain.auth.entity.AuthUser;
 import com.dart.api.domain.member.repository.MemberRepository;
 import com.dart.api.domain.notification.entity.Notification;
+import com.dart.api.domain.notification.repository.PendingEventsRepository;
 import com.dart.api.domain.notification.repository.SSESessionRepository;
 import com.dart.api.dto.notification.response.NotificationReadDto;
 import com.dart.global.error.exception.UnauthorizedException;
@@ -21,8 +22,9 @@ public class SSENotificationService {
 
 	private final MemberRepository memberRepository;
 	private final SSESessionRepository sseSessionRepository;
+	private final PendingEventsRepository pendingEventsRepository;
 
-	public SseEmitter subscribe(AuthUser authUser) {
+	public SseEmitter subscribe(AuthUser authUser, String lastEventId) {
 		final Long memberId = getMemberIdFromAuthUser(authUser);
 
 		final SseEmitter sseEmitter = sseSessionRepository.saveSSEEmitter(memberId, SSE_DEFAULT_TIMEOUT);
@@ -30,6 +32,13 @@ public class SSENotificationService {
 			SSE_CONNECTION_SUCCESS_MESSAGE, null
 		);
 		sseSessionRepository.sendEvent(memberId, notificationReadDto);
+
+		if (lastEventId != null && !lastEventId.isEmpty()) {
+			pendingEventsRepository.getPendingEvents(memberId).stream()
+				.filter(pendingEvent -> lastEventId.compareTo(pendingEvent.eventId()) < 0)
+				.forEach(pendingEvent -> sseSessionRepository.sendEvent(memberId, pendingEvent));
+			pendingEventsRepository.clearPendingEvents(memberId);
+		}
 
 		return sseEmitter;
 	}

--- a/src/main/java/com/dart/api/domain/notification/entity/Notification.java
+++ b/src/main/java/com/dart/api/domain/notification/entity/Notification.java
@@ -1,5 +1,7 @@
 package com.dart.api.domain.notification.entity;
 
+import java.util.UUID;
+
 import com.dart.api.dto.notification.response.NotificationReadDto;
 import com.dart.global.common.entity.BaseTimeEntity;
 
@@ -41,6 +43,7 @@ public class Notification extends BaseTimeEntity {
 
 	public static NotificationReadDto createNotificationReadDto(String message, String type) {
 		return NotificationReadDto.builder()
+			.eventId(UUID.randomUUID().toString())
 			.message(message)
 			.type(type)
 			.build();

--- a/src/main/java/com/dart/api/domain/notification/repository/PendingEventsRepository.java
+++ b/src/main/java/com/dart/api/domain/notification/repository/PendingEventsRepository.java
@@ -1,0 +1,33 @@
+package com.dart.api.domain.notification.repository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.springframework.stereotype.Repository;
+
+import com.dart.api.dto.notification.response.NotificationReadDto;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Repository
+public class PendingEventsRepository {
+
+	public final Map<Long, List<NotificationReadDto>> pendingEventsDB = new ConcurrentHashMap<>();
+
+	public void savePendingEventCache(Long clientId, NotificationReadDto notificationReadDto) {
+		pendingEventsDB.computeIfAbsent(clientId, clientIdKey -> new CopyOnWriteArrayList<>()).add(notificationReadDto);
+		log.info("[✅ LOGGER] PENDING EVENT SAVED FOR CLIENT ID: {} WITH EVENT ID: {}", clientId, notificationReadDto.eventId());
+	}
+
+	public List<NotificationReadDto> getPendingEvents(Long clientId) {
+		return pendingEventsDB.getOrDefault(clientId, new CopyOnWriteArrayList<>());
+	}
+
+	public void clearPendingEvents(Long clientId) {
+		pendingEventsDB.remove(clientId);
+		log.info("[✅ LOGGER] PENDING EVENTS CLEARED FOR CLIENT ID: {}", clientId);
+	}
+}

--- a/src/main/java/com/dart/api/dto/notification/response/NotificationReadDto.java
+++ b/src/main/java/com/dart/api/dto/notification/response/NotificationReadDto.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 
 @Builder
 public record NotificationReadDto(
+	String eventId,
 	Object message,
 	String type
 ) {

--- a/src/main/java/com/dart/api/presentation/NotificationController.java
+++ b/src/main/java/com/dart/api/presentation/NotificationController.java
@@ -3,6 +3,7 @@ package com.dart.api.presentation;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -21,7 +22,10 @@ public class NotificationController {
 	private final SSENotificationService SSENotificationService;
 
 	@GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-	public ResponseEntity<SseEmitter> subscribe(@Auth AuthUser authUser) {
-		return ResponseEntity.ok(SSENotificationService.subscribe(authUser));
+	public ResponseEntity<SseEmitter> subscribe(
+		@Auth AuthUser authUser,
+		@RequestHeader(value="Last-Event-ID", required = false, defaultValue = "") String lastEventId
+	) {
+		return ResponseEntity.ok(SSENotificationService.subscribe(authUser, lastEventId));
 	}
 }

--- a/src/main/java/com/dart/global/common/util/SSEConstant.java
+++ b/src/main/java/com/dart/global/common/util/SSEConstant.java
@@ -8,6 +8,7 @@ public class SSEConstant {
 
 	public static final long SSE_DEFAULT_TIMEOUT = 60 * 60 * 1000L;
 	public static final long SSE_CREATE_GALLERY_TIMEOUT = 60 * 1000L;
+	public static final int EVENT_ID_COMPARISON_RESULT = 0;
 	public static final String SSE_EMITTER_EVENT_NAME = "notification";
 	public static final String DAILY_AT_MIDNIGHT = "0 0 0 * * ?";
 

--- a/src/test/java/com/dart/api/domain/notification/repository/PendingEventsRepositoryTest.java
+++ b/src/test/java/com/dart/api/domain/notification/repository/PendingEventsRepositoryTest.java
@@ -1,0 +1,92 @@
+package com.dart.api.domain.notification.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.dart.api.dto.notification.response.NotificationReadDto;
+
+@ExtendWith(MockitoExtension.class)
+class PendingEventsRepositoryTest {
+
+	@InjectMocks
+	private PendingEventsRepository pendingEventsRepository;
+
+	@Test
+	@DisplayName("SAVE PENDING EVENT CACHE(⭕️ SUCCESS): 성공적으로 대기 중인 이벤트를 캐시에 저장했습니다.")
+	void savePendingEventCache_void_success() {
+		// GIVEN
+		Long clientID = 1L;
+
+		NotificationReadDto notificationReadDto1 = new NotificationReadDto("event-1", "message1", "type1");
+		NotificationReadDto notificationReadDto2 = new NotificationReadDto("event-2", "message2", "type2");
+
+		// WHEN
+		pendingEventsRepository.savePendingEventCache(clientID, notificationReadDto1);
+		pendingEventsRepository.savePendingEventCache(clientID, notificationReadDto2);
+
+		// THEN
+		List<NotificationReadDto> pendingEventsReadDtoList = pendingEventsRepository.getPendingEvents(clientID);
+		assertThat(pendingEventsReadDtoList).hasSize(2);
+		assertThat(pendingEventsReadDtoList).contains(notificationReadDto1, notificationReadDto2);
+	}
+
+	@Test
+	@DisplayName("GET PENDING EVENTS(⭕️ SUCCESS): 성공적으로 대기 중인 이벤트를 캐시에서 조회했습니다.")
+	void getPendingEvents_void_success() {
+		// GIVEN
+		Long clientID = 1L;
+
+		NotificationReadDto notificationReadDto1 = new NotificationReadDto("event-1", "message1", "type1");
+		NotificationReadDto notificationReadDto2 = new NotificationReadDto("event-2", "message2", "type2");
+
+		pendingEventsRepository.savePendingEventCache(clientID, notificationReadDto1);
+		pendingEventsRepository.savePendingEventCache(clientID, notificationReadDto2);
+
+		// WHEN
+		List<NotificationReadDto> pendingEventsReadDtoList = pendingEventsRepository.getPendingEvents(clientID);
+
+		// THEN
+		assertThat(pendingEventsReadDtoList).hasSize(2);
+		assertThat(pendingEventsReadDtoList).contains(notificationReadDto1, notificationReadDto2);
+	}
+
+	@Test
+	@DisplayName("GET PENDING EVENTS CLIENT NOT EXIST(❌️ FAILURE): 사용자가 존재하지 않아 대기 중인 이벤트 조회에 실패했습니다.")
+	void getPendingEvents_clientNotExist_fail() {
+		// GIVEN
+		Long clientID = 999L;
+
+		// WHEN
+		List<NotificationReadDto> pendingEventsReadDtoList = pendingEventsRepository.getPendingEvents(clientID);
+
+		// THEN
+		assertThat(pendingEventsReadDtoList).isEmpty();
+	}
+
+	@Test
+	@DisplayName("CLEAR PENDING EVENTS(⭕️ SUCCESS): 성공적으로 대기 중인 이벤트를 캐시에서 삭제했습니다.")
+	void clearPendingEvents_void_success() {
+		// GIVEN
+		Long clientID = 1L;
+
+		NotificationReadDto notificationReadDto1 = new NotificationReadDto("event-1", "message1", "type1");
+		NotificationReadDto notificationReadDto2 = new NotificationReadDto("event-2", "message2", "type2");
+
+		pendingEventsRepository.savePendingEventCache(clientID, notificationReadDto1);
+		pendingEventsRepository.savePendingEventCache(clientID, notificationReadDto2);
+
+		// WHEN
+		pendingEventsRepository.clearPendingEvents(clientID);
+
+		// THEN
+		List<NotificationReadDto> pendingEventsReadDtoList = pendingEventsRepository.getPendingEvents(clientID);
+		assertThat(pendingEventsReadDtoList).isEmpty();
+	}
+}

--- a/src/test/java/com/dart/api/presentation/NotificationControllerTest.java
+++ b/src/test/java/com/dart/api/presentation/NotificationControllerTest.java
@@ -33,11 +33,12 @@ class NotificationControllerTest {
 	@DisplayName("SUBSCRIBE SSE(⭕️ SUCCESS): 성공적으로 SSE에 연결 및 구독했습니다.")
 	void subscribe_void_success() {
 		// GIVEN
+		String lastEventId = "last-event-id";
 		AuthUser authUser = AuthFixture.createAuthUserEntity();
-		when(sseNotificationService.subscribe(any(AuthUser.class))).thenReturn(sseEmitter);
+		when(sseNotificationService.subscribe(any(AuthUser.class), any(String.class))).thenReturn(sseEmitter);
 
 		// WHEN
-		ResponseEntity<SseEmitter> responseEntity = notificationController.subscribe(authUser);
+		ResponseEntity<SseEmitter> responseEntity = notificationController.subscribe(authUser, lastEventId);
 
 		// THEN
 		assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);


### PR DESCRIPTION
## 📋 CheckList
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. feat: 유저 조회 기능 구현)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

* close #399 

## 👩‍💻 공유 포인트 및 논의 사항
* 지난 이벤트 알림을 받을 수 있도록 해당 이벤트를 저장하는 저장소를 구현했습니다.
* 지난 이벤트 알림을 구분할 수 있도록 이벤트 ID 값을 응답 값으로 추가했습니다.
* 지난 이벤트 알림을 받을 수 있는 로직의 테스트 코드를 작성했습니다.
