### PR TITLE
refactor: 썸네일 이미지 처리 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,9 @@ dependencies {
     // S3
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
+    // Image-Metadate
+    implementation 'com.drewnoakes:metadata-extractor:2.16.0'
+
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'redis.clients:jedis:4.2.3'

--- a/src/main/java/com/dart/api/application/gallery/GalleryService.java
+++ b/src/main/java/com/dart/api/application/gallery/GalleryService.java
@@ -246,8 +246,9 @@ public class GalleryService {
 	}
 
 	private GalleryAllResDto convertToGalleryAllResDto(Gallery gallery) {
+		final List<String> hashtags = hashtagService.findHashtagsByGallery(gallery);
 		return new GalleryAllResDto(gallery.getId(), gallery.getThumbnail(), gallery.getTitle(), gallery.getStartDate(),
-			gallery.getEndDate());
+			gallery.getEndDate(), hashtags);
 	}
 
 	private void validateRequest(String nickname, AuthUser authUser) {

--- a/src/main/java/com/dart/api/dto/gallery/response/GalleryAllResDto.java
+++ b/src/main/java/com/dart/api/dto/gallery/response/GalleryAllResDto.java
@@ -1,12 +1,14 @@
 package com.dart.api.dto.gallery.response;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record GalleryAllResDto(
 	Long galleryId,
 	String thumbnail,
 	String title,
 	LocalDateTime startDate,
-	LocalDateTime endDate
+	LocalDateTime endDate,
+	List<String> hashtags
 ) {
 }

--- a/src/main/java/com/dart/global/common/util/GlobalConstant.java
+++ b/src/main/java/com/dart/global/common/util/GlobalConstant.java
@@ -24,8 +24,6 @@ public class GlobalConstant {
 	public static final int THIRTY_MINUTES = 30 * 60;
 	public static final int THIRTY_DAYS = 30 * 24 * 60 * 60;
 
-	public static final int THUMBNAIL_RESIZING_SIZE = 800;
-
 	public static final int ONE_HUNDRED_PERCENT = 100;
 
 	public static final int INCREMENT_BY_ONE = 1;
@@ -34,5 +32,4 @@ public class GlobalConstant {
 
 	public static final int SECOND_SORT = 1;
 
-	public static final String WATERMARK_TEXT = "D'art";
 }

--- a/src/main/java/com/dart/global/common/util/ImageConstant.java
+++ b/src/main/java/com/dart/global/common/util/ImageConstant.java
@@ -1,0 +1,16 @@
+package com.dart.global.common.util;
+
+public class ImageConstant {
+	public static final int ORIENTATION_ROTATE_90 = 6;
+	public static final int ORIENTATION_ROTATE_180 = 3;
+	public static final int ORIENTATION_ROTATE_270 = 8;
+	public static final int ROTATE_90_DEGREES = 90;
+	public static final int ROTATE_180_DEGREES = 180;
+	public static final int ROTATE_270_DEGREES = 270;
+
+	public static final int THUMBNAIL_RESIZING_SIZE = 800;
+
+	public static final int MINIMUM_RESIZING_SIZE = 240;
+
+	public static final String WATERMARK_TEXT = "D'art";
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -41,7 +41,7 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -41,7 +41,7 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
## 📋 CheckList
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. feat: 유저 조회 기능 구현)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 이슈 번호 #406 

* close #406 

## 👩‍💻 공유 포인트 및 논의 사항
**문제 상황:** 
배포서버에 포스트맨으로 이미지를 입력하면 썸네일과 전시 이미지들이 몇몇 이미지들이 회전되어 업로드 되고, 배포된 페이지에서 업로드를 하면 썸네일만 회전되고 전시 이미지들은 회전되지 않는 경우를 발견하였습니다. 해당이미지에 대해 로컬에서 포스트맨으로 테스트하면 배포 서버에 포스트맨으로 입력한 것과 같이 회전되어 업로드 되는 현상이 있었습니다.
**이유:** 
이미지의 메타 데이터에 exif란 것이 있는데 이미지 파일 메타데이터 포맷이라고 합니다. 이미지를 찍을 때 회전에 대한 정보가 저장되는 것이라고 합니다. 
**해결:** 
exif의 회전 정보를 확인하고, 회전되는 이미지는 제대로 보이게 회전하여 이미지를 처리하도록 하였습니다. 로컬에서 포스트맨으로 전과 같은 이미지를 입력했을 때 제대로 업로드되는 것을 확인했습니다. 
어제 문제 상황에서는 배포 사이트에서 입력하면 썸네일만 회전되어 업로드 되었기 때문에 이에 대해 빠르게 테스트해보고 싶습니다.
+ 전시 전체 조회 시 해시태그를 다시 보내달라고 하셔서 추가하였습니다.
+ 전시 썸네일의 경우 800*800보다 큰경우 긴쪽을 800으로 기준으로 잡고 원본 비율을 유지하여 리사이징하고 있었습니다.
여기에 240*240보다 작은 경우는 짧은 쪽을 240으로 기준으로 잡고 원본 비율을 유지하여 리사이징하도록 추가하였습니다.
