### PR TITLE
feat: 재전시 요청 횟수가 10회 초과 시 작가에게 알림 전송 로직 구현

### DIFF
--- a/src/main/java/com/dart/api/application/notification/ExhibitionNotificationService.java
+++ b/src/main/java/com/dart/api/application/notification/ExhibitionNotificationService.java
@@ -1,0 +1,45 @@
+package com.dart.api.application.notification;
+
+import static com.dart.global.common.util.SSEConstant.*;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.dart.api.domain.gallery.entity.Gallery;
+import com.dart.api.domain.gallery.repository.GalleryRepository;
+import com.dart.api.domain.notification.entity.Notification;
+import com.dart.api.domain.notification.entity.NotificationType;
+import com.dart.api.domain.notification.repository.SSESessionRepository;
+import com.dart.api.dto.notification.response.NotificationReadDto;
+import com.dart.global.error.exception.NotFoundException;
+import com.dart.global.error.model.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ExhibitionNotificationService {
+
+	private final SSESessionRepository sseSessionRepository;
+	private final GalleryRepository galleryRepository;
+
+	@Transactional
+	public void sendReExhibitionRequestNotification(Long galleryId) {
+		final Long authorId = getAuthorIdByGalleryId(galleryId);
+		notificationAuthorAboutReExhibitionRequest(authorId);
+	}
+
+	private void notificationAuthorAboutReExhibitionRequest(Long memberId) {
+		final NotificationReadDto notificationReadDto = Notification.createNotificationReadDto(
+			REEXHIBITION_REQUEST_MESSAGE, NotificationType.REEXHIBITION.getName());
+
+		sseSessionRepository.sendEvent(memberId, notificationReadDto);
+	}
+
+	private Long getAuthorIdByGalleryId(Long galleryId) {
+		return galleryRepository.findById(galleryId)
+			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_GALLERY_NOT_FOUND))
+			.getMember().getId();
+	}
+}

--- a/src/main/java/com/dart/api/domain/gallery/entity/Gallery.java
+++ b/src/main/java/com/dart/api/domain/gallery/entity/Gallery.java
@@ -130,4 +130,12 @@ public class Gallery extends BaseTimeEntity {
 	public GalleryReadIdDto toReadIdDto() {
 		return new GalleryReadIdDto(this.id);
 	}
+
+	public void incrementReExhibitionRequestCount() {
+		this.reExhibitionRequestCount++;
+	}
+
+	public void resetReExhibitionRequestCount() {
+		this.reExhibitionRequestCount = 0;
+	}
 }

--- a/src/main/java/com/dart/api/domain/notification/entity/NotificationType.java
+++ b/src/main/java/com/dart/api/domain/notification/entity/NotificationType.java
@@ -9,7 +9,8 @@ import lombok.RequiredArgsConstructor;
 public enum NotificationType {
 
 	LIVE("live"),
-	COUPON("coupon");
+	COUPON("coupon"),
+	REEXHIBITION("reexhibition");
 
 	private final String name;
 }

--- a/src/main/java/com/dart/api/presentation/GalleryController.java
+++ b/src/main/java/com/dart/api/presentation/GalleryController.java
@@ -2,6 +2,7 @@ package com.dart.api.presentation;
 
 import java.util.List;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -9,10 +10,12 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -83,5 +86,12 @@ public class GalleryController {
 	public ResponseEntity<GalleryInfoDto> getGalleryInfo(@RequestParam("gallery-id") Long galleryId,
 		@Auth(required = false) AuthUser authUser) {
 		return ResponseEntity.ok(galleryService.getGalleryInfo(galleryId, authUser));
+	}
+
+	@PutMapping("/reexhibition")
+	@ResponseStatus(HttpStatus.OK)
+	public ResponseEntity<String> updateReExhibitionRequestCount(@RequestParam("gallery-id") Long galleryId) {
+		galleryService.updateReExhibitionRequestCount(galleryId);
+		return ResponseEntity.ok("OK");
 	}
 }

--- a/src/main/java/com/dart/global/common/util/SSEConstant.java
+++ b/src/main/java/com/dart/global/common/util/SSEConstant.java
@@ -9,9 +9,11 @@ public class SSEConstant {
 	public static final long SSE_DEFAULT_TIMEOUT = 60 * 60 * 1000L;
 	public static final long SSE_CREATE_GALLERY_TIMEOUT = 60 * 1000L;
 	public static final int EVENT_ID_COMPARISON_RESULT = 0;
+	public static final int REEXHIBITION_REQUEST_COUNT = 10;
 	public static final String SSE_EMITTER_EVENT_NAME = "notification";
 	public static final String DAILY_AT_MIDNIGHT = "0 0 0 * * ?";
 
 	public static final String SSE_CONNECTION_SUCCESS_MESSAGE = "SSE에 성공적으로 연결되었습니다.";
 	public static final String LIVE_COUPON_ISSUED_MESSAGE = "실시간 쿠폰이 발행되었습니다.";
+	public static final String REEXHIBITION_REQUEST_MESSAGE = "재전시 요청이 10회를 초과했습니다. 새로운 재전시 요청이 들어왔으니 확인해 주세요.";
 }

--- a/src/test/java/com/dart/api/application/notification/ExhibitionNotificationServiceTest.java
+++ b/src/test/java/com/dart/api/application/notification/ExhibitionNotificationServiceTest.java
@@ -1,0 +1,68 @@
+package com.dart.api.application.notification;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.dart.api.domain.gallery.entity.Gallery;
+import com.dart.api.domain.gallery.repository.GalleryRepository;
+import com.dart.api.domain.notification.repository.SSESessionRepository;
+import com.dart.api.dto.notification.response.NotificationReadDto;
+import com.dart.global.error.exception.NotFoundException;
+import com.dart.support.GalleryFixture;
+
+@ExtendWith(MockitoExtension.class)
+class ExhibitionNotificationServiceTest {
+
+	@Mock
+	private SSESessionRepository sseSessionRepository;
+
+	@Mock
+	private GalleryRepository galleryRepository;
+
+	@InjectMocks
+	private ExhibitionNotificationService exhibitionNotificationService;
+
+	@Test
+	@DisplayName("SEND RE-EXHIBITION REQUEST NOTIFICATION(⭕️ SUCCESS): 성공적으로 재전시 요청 알림을 전송했습니다.")
+	void sendReExhibitionRequestNotification_void_success() {
+		// GIVEN
+		Long galleryId = 1L;
+		Gallery gallery = GalleryFixture.createGalleryEntity();
+		Long authorId = gallery.getMember().getId();
+
+		when(galleryRepository.findById(anyLong())).thenReturn(Optional.of(gallery));
+		doNothing().when(sseSessionRepository).sendEvent(eq(authorId), any(NotificationReadDto.class));
+
+		// WHEN
+		exhibitionNotificationService.sendReExhibitionRequestNotification(galleryId);
+
+		// THEN
+		verify(sseSessionRepository).sendEvent(eq(authorId), any(NotificationReadDto.class));
+		verify(galleryRepository).findById(galleryId);
+	}
+
+	@Test
+	@DisplayName("SEND RE-EXHIBITION REQUEST NOTIFICATION(❌ FAILURE): 전시회를 찾을 수 없어 재전시 요청 알림 전송에 실패했습니다.")
+	void sendReExhibitionRequestNotification_NotFoundException_fail() {
+		// GIVEN
+		Long galleryId = 1L;
+
+		when(galleryRepository.findById(galleryId)).thenReturn(Optional.empty());
+
+		// WHEN & THEN
+		assertThatThrownBy(() -> exhibitionNotificationService.sendReExhibitionRequestNotification(galleryId))
+			.isInstanceOf(NotFoundException.class)
+			.hasMessageContaining("[❎ ERROR] 요청하신 전시관을 찾을 수 없습니다.");
+
+		verify(sseSessionRepository, never()).sendEvent(anyLong(), any(NotificationReadDto.class));
+	}
+}


### PR DESCRIPTION
## 📋 CheckList
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. feat: 유저 조회 기능 구현)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

* close #408

## 👩‍💻 공유 포인트 및 논의 사항
* 재전시 요청을 진행할 수 있는 서비스 로직 및 엔드포인트를 설정했습니다.
* 재전시 요청 횟수 10회 초과 시 작가에게 알림이 전송되도록 했습니다.
