### PR TITLE
refactor: 실시간 채팅 메시지 목록 조회 시 성능 최적화

### DIFF
--- a/src/main/java/com/dart/global/common/util/RedisConstant.java
+++ b/src/main/java/com/dart/global/common/util/RedisConstant.java
@@ -12,9 +12,9 @@ public class RedisConstant {
 	public static final String REDIS_REFRESH_TOKEN_PREFIX = "token:refresh:";
 	public static final String REDIS_BLACKLIST_TOKEN_PREFIX = "token:blacklist:";
 	public static final String REDIS_EMAIL_PREFIX = "email:";
-	public static final String REDIS_GALLERY_PREFIX = "gallery:";
 	public static final String REDIS_PAYMENT_PREFIX = "payment:";
 	public static final String REDIS_CHAT_MESSAGE_PREFIX = "chatMessage:";
+	public static final String REDIS_BATCH_PREFIX = "batch:chatMessages";
 	public static final String REDIS_NICKNAME_PREFIX = "nickname:";
 	public static final String REDIS_COUPON_PREFIX = "coupon:";
 	public static final String REDIS_COUPON_COUNT_PREFIX = "coupon_count:";
@@ -25,9 +25,6 @@ public class RedisConstant {
 
 	public static final String REDIS_SESSION_EMAIL_PREFIX = "session-email:";
 	public static final String REDIS_SESSION_NICKNAME_PREFIX = "session-nickname:";
-
-	public final static long LIST_START_INDEX = 0;
-	public final static long LIST_END_INDEX_ALL = -1;
 
 	public static final String CODE = "code";
 	public static final String RESERVED = "reserved";

--- a/src/test/java/com/dart/api/application/chat/ChatMessageServiceTest.java
+++ b/src/test/java/com/dart/api/application/chat/ChatMessageServiceTest.java
@@ -3,6 +3,7 @@ package com.dart.api.application.chat;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
@@ -99,5 +100,42 @@ class ChatMessageServiceTest {
 			() -> chatMessageService.saveChatMessage(chatRoomId, chatMessageCreateDto))
 			.isInstanceOf(NotFoundException.class)
 			.hasMessage("[❎ ERROR] 요청하신 회원을 찾을 수 없습니다.");
+	}
+
+	@Test
+	@DisplayName("BATCH SAVE MESSAGES(⭕️ SUCCESS): REDIS에 저장된 배치 메시지를 데이터베이스에 저장했습니다.")
+	void batchSaveMessages_void_success() {
+		// GIVEN
+		ChatRoom chatRoom = ChatFixture.createChatRoomEntity();
+		Member member = MemberFixture.createMemberEntity();
+		ChatMessageCreateDto chatMessageCreateDto = ChatFixture.createChatMessageEntityForChatMessageCreateDto();
+		ChatMessage chatMessage = ChatFixture.createChatMessageEntity(chatRoom, member, chatMessageCreateDto);
+
+		List<ChatMessage> chatMessageList = List.of(chatMessage);
+
+		when(chatRedisRepository.getAllBatchMessages()).thenReturn(chatMessageList);
+
+		// WHEN
+		chatMessageService.batchSaveMessages();
+
+		// THEN
+		verify(chatMessageRepository, times(1)).saveAll(chatMessageList);
+		verify(chatRedisRepository, times(1)).clearBatchMessages();
+	}
+
+	@Test
+	@DisplayName("BATCH SAVE MESSAGES(⭕️ SUCCESS): REDIS에 저장된 메시지가 없어 데이터베이스에 저장하지 않습니다.")
+	void batchSaveMessages_noMessages_void_success() {
+		// GIVEN
+		List<ChatMessage> chatMessageList = List.of();
+
+		when(chatRedisRepository.getAllBatchMessages()).thenReturn(chatMessageList);
+
+		// WHEN
+		chatMessageService.batchSaveMessages();
+
+		// THEN
+		verify(chatMessageRepository, times(0)).saveAll(anyList());
+		verify(chatRedisRepository, times(0)).clearBatchMessages();
 	}
 }

--- a/src/test/java/com/dart/api/domain/chat/repository/ChatRedisRepositoryTest.java
+++ b/src/test/java/com/dart/api/domain/chat/repository/ChatRedisRepositoryTest.java
@@ -10,12 +10,14 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.dart.api.domain.chat.entity.ChatMessage;
+import com.dart.api.domain.chat.entity.ChatRoom;
 import com.dart.api.domain.member.entity.Member;
+import com.dart.api.dto.chat.request.ChatMessageCreateDto;
 import com.dart.api.dto.chat.request.ChatMessageSendDto;
 import com.dart.api.dto.chat.response.ChatMessageReadDto;
 import com.dart.api.dto.page.PageResponse;
@@ -42,8 +44,7 @@ class ChatRedisRepositoryTest {
 	void saveChatMessage_void_success() throws JsonProcessingException {
 		// GIVEN
 		ChatMessageSendDto chatMessageSendDto = ChatFixture.createChatMessageSendDto(
-			1L, 1L, "Hello 👋🏻", LocalDateTime.now(), true
-		);
+			1L, 1L, "Hello 👋🏻", LocalDateTime.now(), true);
 		Member member = MemberFixture.createMemberEntity();
 
 		when(objectMapper.writeValueAsString(any(ChatMessageReadDto.class))).thenReturn("JSONValue");
@@ -52,17 +53,9 @@ class ChatRedisRepositoryTest {
 		chatRedisRepository.saveChatMessage(chatMessageSendDto, member);
 
 		// THEN
-		ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
-		ArgumentCaptor<String> valueCaptor = ArgumentCaptor.forClass(String.class);
-		ArgumentCaptor<Long> expiryCaptor = ArgumentCaptor.forClass(Long.class);
-
-		verify(listRedisRepository).addElementWithExpiry(
-			keyCaptor.capture(), valueCaptor.capture(), expiryCaptor.capture()
-		);
-
-		assertEquals(REDIS_CHAT_MESSAGE_PREFIX + chatMessageSendDto.chatRoomId(), keyCaptor.getValue());
-		assertEquals("JSONValue", valueCaptor.getValue());
-		assertEquals(chatMessageSendDto.expirySeconds(), expiryCaptor.getValue());
+		String expectedKey = REDIS_CHAT_MESSAGE_PREFIX + chatMessageSendDto.chatRoomId();
+		verify(listRedisRepository).addElementWithExpiry(expectedKey, "JSONValue", chatMessageSendDto.expirySeconds());
+		verify(listRedisRepository).addElement(REDIS_BATCH_PREFIX, "JSONValue");
 	}
 
 	@Test
@@ -81,14 +74,43 @@ class ChatRedisRepositoryTest {
 			.thenReturn(new ChatMessageReadDto("sender2", "content2", LocalDateTime.now(), false, "profileImageURL2"));
 
 		// WHEN
-		PageResponse<ChatMessageReadDto> pageResponse = chatRedisRepository.getChatMessageReadDto(chatRoomId, page,
-			size);
+		PageResponse<ChatMessageReadDto> pageResponse = chatRedisRepository.getChatMessageReadDto(
+			chatRoomId, page, size);
 
 		// THEN
 		assertEquals(2, pageResponse.pages().size());
 		assertEquals("sender1", pageResponse.pages().get(0).sender());
 		assertEquals("sender2", pageResponse.pages().get(1).sender());
 		assertTrue(pageResponse.pageInfo().isDone());
+	}
+
+	@Test
+	@DisplayName("GET ALL BATCH CHAT MESSAGE(⭕️ SUCCESS): 성공적으로 BATCH 채팅 메시지를 조회했습니다.")
+	void getAllBatchMessages_void_success() throws JsonProcessingException {
+		// GIVEN
+		List<Object> batchMessageValues = List.of("JSONValue1", "JSONValue2");
+
+		ChatRoom chatRoom = ChatFixture.createChatRoomEntity();
+
+		Member member1 = MemberFixture.createMemberEntityWithEmailAndNickname("sender1@example.com", "sender1");
+		Member member2 = MemberFixture.createMemberEntityWithEmailAndNickname("sender2@example.com", "sender2");
+
+		ChatMessageCreateDto chatMessageCreateDto = ChatFixture.createChatMessageEntityForChatMessageCreateDto();
+
+		ChatMessage chatMessage1 = ChatFixture.createChatMessageEntity(chatRoom, member1, chatMessageCreateDto);
+		ChatMessage chatMessage2 = ChatFixture.createChatMessageEntity(chatRoom, member2, chatMessageCreateDto);
+
+		when(listRedisRepository.getRange(eq(REDIS_BATCH_PREFIX), eq(0L), eq(-1L))).thenReturn(batchMessageValues);
+		when(objectMapper.readValue(eq("JSONValue1"), eq(ChatMessage.class))).thenReturn(chatMessage1);
+		when(objectMapper.readValue(eq("JSONValue2"), eq(ChatMessage.class))).thenReturn(chatMessage2);
+
+		// WHEN
+		List<ChatMessage> batchChatMessageList = chatRedisRepository.getAllBatchMessages();
+
+		// THEN
+		assertEquals(2, batchChatMessageList.size());
+		assertEquals("Hello 👋🏻", batchChatMessageList.get(0).getContent());
+		assertEquals("Hello 👋🏻", batchChatMessageList.get(1).getContent());
 	}
 
 	@Test
@@ -102,5 +124,15 @@ class ChatRedisRepositoryTest {
 
 		// THEN
 		verify(listRedisRepository, times(1)).deleteAllElements(REDIS_CHAT_MESSAGE_PREFIX + chatRoomId);
+	}
+
+	@Test
+	@DisplayName("CLEAR BATCH MESSAGES(⭕️ SUCCESS): 성공적으로 배치 메시지를 삭제했습니다.")
+	void clearBatchMessages_void_success() {
+		// WHEN
+		chatRedisRepository.clearBatchMessages();
+
+		// THEN
+		verify(listRedisRepository, times(1)).deleteAllElements(REDIS_BATCH_PREFIX);
 	}
 }


### PR DESCRIPTION
## 📋 CheckList
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. feat: 유저 조회 기능 구현)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

* close #419 

## 👩‍💻 공유 포인트 및 논의 사항
* 채팅 메시지 저장 시 스케줄러를 이용해서 5분 단위로 배치 저장을 하도록 했습니다.
* 채팅 메시지 조회 시 Redis 캐시를 이용해 읽기 성능을 최적화했습니다.
