### PR TITLE
fix: 사용자정보 수정시 발생하는 오류 해결

### DIFF
--- a/src/main/java/com/dart/api/application/member/MemberService.java
+++ b/src/main/java/com/dart/api/application/member/MemberService.java
@@ -60,6 +60,7 @@ public class MemberService {
 		cleanUpSessionData(sessionId, signUpDto.email(), signUpDto.nickname());
 	}
 
+	@Transactional(readOnly = true)
 	public MemberProfileResDto getMemberProfile(String nickname, AuthUser authUser) {
 		validateMemberExists(nickname);
 		if(isOwnProfile(authUser, nickname)) {

--- a/src/main/java/com/dart/api/application/member/MemberService.java
+++ b/src/main/java/com/dart/api/application/member/MemberService.java
@@ -78,9 +78,9 @@ public class MemberService {
 
 		Member member = findMemberByEmail(authUser.email());
 		validateNickname(memberUpdateDto.nickname(), member.getNickname(), sessionId);
-		String newProfileImageUrl = handleProfileImageUpdate(profileImage, member.getProfileImageUrl());
+		handleProfileImageUpdate(profileImage, member);
 
-		member.updateProfile(memberUpdateDto, newProfileImageUrl);
+		member.updateProfile(memberUpdateDto);
 		handleNicknameUpdate(memberUpdateDto.nickname(), member.getNickname(), sessionId);
 
 		return new MemberSimpleProfileResDto(member.getEmail(), member.getNickname(), member.getProfileImageUrl());
@@ -99,15 +99,15 @@ public class MemberService {
 		}
 	}
 
-	private String handleProfileImageUpdate(MultipartFile profileImage, String savedProfileImage) {
-		if (profileImage == null || profileImage.isEmpty()) return null;
+	private void handleProfileImageUpdate(MultipartFile profileImage, Member member) {
+		if (profileImage == null || profileImage.isEmpty()) return;
 
+		String savedProfileImage = member.getProfileImageUrl();
 		String newProfileImageUrl = s3Service.uploadFile(profileImage);
 		if (savedProfileImage != null) {
 			s3Service.deleteFile(savedProfileImage);
 		}
-
-		return newProfileImageUrl;
+		member.updateProfileImage(newProfileImageUrl);
 	}
 
 	private void handleNicknameUpdate(String newNickname, String currentNickname, String sessionId) {

--- a/src/main/java/com/dart/api/domain/member/entity/Member.java
+++ b/src/main/java/com/dart/api/domain/member/entity/Member.java
@@ -77,9 +77,8 @@ public class Member extends BaseTimeEntity {
 			.build();
 	}
 
-	public void updateProfile(MemberUpdateDto memberUpdateDto, String profileImageUrl) {
+	public void updateProfile(MemberUpdateDto memberUpdateDto) {
 		this.nickname = memberUpdateDto.nickname();
-		this.profileImageUrl = profileImageUrl;
 		this.introduce = memberUpdateDto.introduce();
 	}
 


### PR DESCRIPTION
## 📋 CheckList
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. feat: 유저 조회 기능 구현)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 #433 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

* close #433

## 👩‍💻 공유 포인트 및 논의 사항
* 사용자 정보 수정시, 프로필 이미지를 업데이트하지 않으면 기본값으로 돌아가는 오류가 발생하였습니다.
* 관련하여 updateProfile, handleMemberProfileUpdate 메소드를 수정하였습니다.

* 사용자 정보 수정 후 정보 조회시, 사용자의 생일이 '정보없음'으로 표시되는 오류가 있었습니다.
* 수정이 완료되지 않은 상태에서 조회를 하여 발생한 오류이므로 @transactional(readOnly = true)을 추가하였습니다.