### PR TITLE
refactor: 채팅 메시지 스케줄러를 통해 DB 접근 최소화 및 읽기 성능 최적화

### DIFF
--- a/src/main/java/com/dart/api/application/chat/ChatMessageReadService.java
+++ b/src/main/java/com/dart/api/application/chat/ChatMessageReadService.java
@@ -50,6 +50,8 @@ public class ChatMessageReadService {
 		final List<ChatMessageReadDto> chatMessageReadDtoList = fetchChatMessagesFromDBAndUpdateMembers(
 			chatRoomId, page, size);
 
+		cachingChatMessages(getChatRoomById(chatRoomId), chatMessageReadDtoList);
+
 		return createPageResponse(chatMessageReadDtoList, page, size);
 	}
 
@@ -63,12 +65,7 @@ public class ChatMessageReadService {
 			.map(ChatMessage::toChatMessageReadDto)
 			.toList();
 
-		final List<ChatMessageReadDto> updatedChatMessageReadDtoList = updateMembersInChatMessages(
-			mySQLChatMessageReadDtoList);
-
-		cachingChatMessages(chatRoom, mySQLChatMessageReadDtoList);
-
-		return updatedChatMessageReadDtoList;
+		return updateMembersInChatMessages(mySQLChatMessageReadDtoList);
 	}
 
 	public List<ChatMessageReadDto> updateMembersInChatMessages(List<ChatMessageReadDto> chatMessageReadDtoList) {

--- a/src/main/java/com/dart/api/application/chat/ChatMessageService.java
+++ b/src/main/java/com/dart/api/application/chat/ChatMessageService.java
@@ -2,6 +2,9 @@ package com.dart.api.application.chat;
 
 import static com.dart.global.common.util.ChatConstant.*;
 
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,10 +36,27 @@ public class ChatMessageService {
 		final ChatRoom chatRoom = getChatRoomById(chatRoomId);
 		final Member member = getMemberByNickname(chatMessageCreateDto.sender());
 		final ChatMessage chatMessage = ChatMessage.chatMessageFromCreateDto(chatRoom, member, chatMessageCreateDto);
-		chatMessageRepository.save(chatMessage);
 
 		final ChatMessageSendDto chatMessageSendDto = chatMessage.toChatMessageSendDto(CHAT_MESSAGE_EXPIRY_SECONDS);
 		chatRedisRepository.saveChatMessage(chatMessageSendDto, member);
+	}
+
+	@Scheduled(cron = CHAT_BATCH_SAVE_INTERVAL)
+	public void batchSaveMessages() {
+		List<Long> activeChatRoomIds = chatRedisRepository.getActiveChatRoomIds();
+
+		activeChatRoomIds.stream()
+			.map(chatRedisRepository::getAllBatchMessages)
+			.filter(chatMessageList -> !chatMessageList.isEmpty())
+			.forEach(chatMessageList -> saveMessagesIfNotEmpty(
+				chatMessageList, chatMessageList.get(0).getChatRoom().getId()));
+	}
+
+	private void saveMessagesIfNotEmpty(List<ChatMessage> chatMessageList, Long chatRoomId) {
+		if (!chatMessageList.isEmpty()) {
+			chatMessageRepository.saveAll(chatMessageList);
+			chatRedisRepository.deleteChatMessages(chatRoomId);
+		}
 	}
 
 	private ChatRoom getChatRoomById(Long chatRoomId) {

--- a/src/main/java/com/dart/api/infrastructure/redis/ListRedisRepository.java
+++ b/src/main/java/com/dart/api/infrastructure/redis/ListRedisRepository.java
@@ -1,11 +1,15 @@
 package com.dart.api.infrastructure.redis;
 
+import static com.dart.global.common.util.GlobalConstant.*;
 import static java.util.Objects.*;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.stereotype.Repository;
 
 import lombok.RequiredArgsConstructor;
@@ -29,6 +33,20 @@ public class ListRedisRepository {
 
 	public List<Object> getRange(String key, long start, long end) {
 		return redisTemplate.opsForList().range(requireNonNull(key), start, end);
+	}
+
+	public List<Long> getActiveChatRoomIds(String keyPrefix) {
+		List<Long> chatRoomIds = new ArrayList<>();
+		ScanOptions scanOptions = ScanOptions.scanOptions().match(keyPrefix + "*").count(1000).build();
+		try (Cursor<byte[]> cursor = redisTemplate.getConnectionFactory().getConnection().scan(scanOptions)) {
+			while (cursor.hasNext()) {
+				String key = new String(cursor.next());
+				String chatRoomId = key.replace(keyPrefix, BLANK);
+				chatRoomIds.add(Long.parseLong(chatRoomId));
+			}
+		}
+
+		return chatRoomIds;
 	}
 
 	public void removeElement(String key, Object value) {

--- a/src/main/java/com/dart/global/common/util/ChatConstant.java
+++ b/src/main/java/com/dart/global/common/util/ChatConstant.java
@@ -12,7 +12,8 @@ public class ChatConstant {
 	public static final String ALLOWED_ORIGIN_PATTERN = "*";
 	public static final String CHAT_SESSION_USER = "authUser";
 	public static final String TOPIC_PREFIX = "/sub/ws/";
-	public final static long CHAT_MESSAGE_EXPIRY_SECONDS = 60 * 60;
+	public static final long CHAT_MESSAGE_EXPIRY_SECONDS = 60 * 60;
+	public static final String CHAT_BATCH_SAVE_INTERVAL = "0 */5 * * * ?";
 
 	public static final int MESSAGE_SIZE_LIMIT = 160 * 64 * 1024;
 	public static final int SEND_TIME_LIMIT = 100 * 10000;

--- a/src/main/java/com/dart/global/common/util/RedisConstant.java
+++ b/src/main/java/com/dart/global/common/util/RedisConstant.java
@@ -37,4 +37,6 @@ public class RedisConstant {
 	public static final long NICKNAME_VERIFICATION_EXPIRATION_TIME_SECONDS = THIRTY_MINUTES;
 	public static final int SESSION_EMAIL_EXPIRATION_TIME_SECONDS = THIRTY_MINUTES;
 	public static final int SESSION_NICKNAME_EXPIRATION_TIME_SECONDS = THIRTY_MINUTES;
+	public static final int REDIS_BATCH_START_INDEX = 0;
+	public static final int REDIS_BATCH_END_INDEX = 100;
 }

--- a/src/test/java/com/dart/api/application/chat/ChatMessageReadServiceTest.java
+++ b/src/test/java/com/dart/api/application/chat/ChatMessageReadServiceTest.java
@@ -124,9 +124,10 @@ class ChatMessageReadServiceTest {
 		// THEN
 		assertThat(actualPageResponse).isEqualTo(expectedPageResponse);
 		verify(chatRedisRepository, times(1)).getChatMessageReadDto(chatRoomId, page, size);
-		verify(chatRoomRepository, times(1)).findById(chatRoomId);
+		verify(chatRoomRepository, times(2)).findById(chatRoomId);
 		verify(chatMessageRepository, times(1)).findByChatRoomOrderByCreatedAtDesc(any(ChatRoom.class),
 			any(Pageable.class));
+		verify(memberRepository, times(1)).findByEmailIn(anyList());
 	}
 
 	@Test
@@ -171,8 +172,6 @@ class ChatMessageReadServiceTest {
 		when(chatMessageRepository.findByChatRoomOrderByCreatedAtDesc(any(ChatRoom.class), any(Pageable.class)))
 			.thenReturn(chatMessagePage);
 		when(memberRepository.findByEmailIn(anyList())).thenReturn(Arrays.asList(member1, member2));
-		when(memberRepository.findByNickname(member1.getNickname())).thenReturn(Optional.of(member1));
-		when(memberRepository.findByNickname(member2.getNickname())).thenReturn(Optional.of(member2));
 
 		// WHEN
 		List<ChatMessageReadDto> actualChatMessageReadDtoList =
@@ -189,7 +188,6 @@ class ChatMessageReadServiceTest {
 		verify(chatMessageRepository, times(1)).findByChatRoomOrderByCreatedAtDesc(
 			any(ChatRoom.class), any(Pageable.class));
 		verify(memberRepository, times(1)).findByEmailIn(anyList());
-		verify(memberRepository, times(2)).findByNickname(anyString());
 	}
 
 	@Test


### PR DESCRIPTION
## 📋 CheckList
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. feat: 유저 조회 기능 구현)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

* close #441 

## 👩‍💻 공유 포인트 및 논의 사항
* 채팅메시지 저장 시 스케줄러를 활용해 5분 단위로 채팅메시지를 배치 저장하도록 했습니다.
* 관련 테스트 코드 작성 및 기존에 작성했던 불필요한 테스트 코드 정리를 진행했습니다.
