### PR TITLE
refactor: 채팅메시지 배치 처리 시 createdAt이 정상적으로 저장되도록 로직 수정

### DIFF
--- a/src/main/java/com/dart/api/domain/chat/repository/ChatRedisRepository.java
+++ b/src/main/java/com/dart/api/domain/chat/repository/ChatRedisRepository.java
@@ -6,8 +6,8 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import com.dart.api.domain.chat.entity.ChatMessage;
 import com.dart.api.domain.member.entity.Member;
+import com.dart.api.dto.chat.request.ChatMessageCreateDto;
 import com.dart.api.dto.chat.request.ChatMessageSendDto;
 import com.dart.api.dto.chat.response.ChatMessageReadDto;
 import com.dart.api.dto.page.PageInfo;
@@ -51,10 +51,10 @@ public class ChatRedisRepository {
 		return new PageResponse<>(chatMessageReadDtoList, pageInfo);
 	}
 
-	public List<ChatMessage> getAllBatchMessages(Long chatRoomId) {
+	public List<ChatMessageCreateDto> getAllBatchMessages(Long chatRoomId) {
 		return listRedisRepository.getRange(REDIS_CHAT_MESSAGE_PREFIX + chatRoomId.toString(), REDIS_BATCH_START_INDEX,
 				REDIS_BATCH_END_INDEX - 1).stream()
-			.map(this::parseChatMessage)
+			.map(this::parseChatMessageCreatedDto)
 			.toList();
 	}
 
@@ -80,9 +80,9 @@ public class ChatRedisRepository {
 		}
 	}
 
-	private ChatMessage parseChatMessage(Object messageValue) {
+	private ChatMessageCreateDto parseChatMessageCreatedDto(Object messageValue) {
 		try {
-			return objectMapper.readValue(messageValue.toString(), ChatMessage.class);
+			return objectMapper.readValue(messageValue.toString(), ChatMessageCreateDto.class);
 		} catch (JsonProcessingException e) {
 			throw new RuntimeException("[✅ LOGGER] FAILED TO PROCESS JSON", e);
 		}

--- a/src/test/java/com/dart/api/domain/chat/repository/ChatRedisRepositoryTest.java
+++ b/src/test/java/com/dart/api/domain/chat/repository/ChatRedisRepositoryTest.java
@@ -90,30 +90,24 @@ class ChatRedisRepositoryTest {
 		List<Object> batchMessageValues = List.of("JSONValue1", "JSONValue2");
 
 		Long chatRoomId = 1L;
-		ChatRoom chatRoom = ChatFixture.createChatRoomEntity();
 
-		Member member1 = MemberFixture.createMemberEntityWithEmailAndNickname("sender1@example.com", "sender1");
-		Member member2 = MemberFixture.createMemberEntityWithEmailAndNickname("sender2@example.com", "sender2");
-
-		ChatMessageCreateDto chatMessageCreateDto = ChatFixture.createChatMessageEntityForChatMessageCreateDto();
-
-		ChatMessage chatMessage1 = ChatFixture.createChatMessageEntity(chatRoom, member1, chatMessageCreateDto);
-		ChatMessage chatMessage2 = ChatFixture.createChatMessageEntity(chatRoom, member2, chatMessageCreateDto);
+		ChatMessageCreateDto chatMessageCreateDto1 = ChatFixture.createChatMessageEntityForChatMessageCreateDto();
+		ChatMessageCreateDto chatMessageCreateDto2 = ChatFixture.createChatMessageEntityForChatMessageCreateDto();
 
 		when(listRedisRepository.getRange(
 			eq(REDIS_CHAT_MESSAGE_PREFIX + chatRoomId.toString()),
 			eq((long)REDIS_BATCH_START_INDEX),
 			eq((long)(REDIS_BATCH_END_INDEX - 1)))).thenReturn(batchMessageValues);
-		when(objectMapper.readValue(eq("JSONValue1"), eq(ChatMessage.class))).thenReturn(chatMessage1);
-		when(objectMapper.readValue(eq("JSONValue2"), eq(ChatMessage.class))).thenReturn(chatMessage2);
+		when(objectMapper.readValue(eq("JSONValue1"), eq(ChatMessageCreateDto.class))).thenReturn(chatMessageCreateDto1);
+		when(objectMapper.readValue(eq("JSONValue2"), eq(ChatMessageCreateDto.class))).thenReturn(chatMessageCreateDto2);
 
 		// WHEN
-		List<ChatMessage> batchChatMessageList = chatRedisRepository.getAllBatchMessages(chatRoomId);
+		List<ChatMessageCreateDto> batchChatMessageList = chatRedisRepository.getAllBatchMessages(chatRoomId);
 
 		// THEN
 		assertEquals(2, batchChatMessageList.size());
-		assertEquals("Hello 👋🏻", batchChatMessageList.get(0).getContent());
-		assertEquals("Hello 👋🏻", batchChatMessageList.get(1).getContent());
+		assertEquals(chatMessageCreateDto1, batchChatMessageList.get(0));
+		assertEquals(chatMessageCreateDto2, batchChatMessageList.get(1));
 	}
 
 	@Test


### PR DESCRIPTION
## 📋 CheckList
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. feat: 유저 조회 기능 구현)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

* close #466 

## 👩‍💻 공유 포인트 및 논의 사항
* 채팅 메시지를 배치 처리를 하여 저장할 때 createdAt이 null로 저장되는 것을 막고 정상적으로 저장되도록 수정했습니다.
* 관련 테스트 코드들 또한 수정했습니다.
