### PR TITLE
refactor: NULL 값이 할당되는 createdAt 필드를 현재 시간으로 설정하도록 수정

### DIFF
--- a/src/main/java/com/dart/api/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/com/dart/api/domain/chat/entity/ChatMessage.java
@@ -52,7 +52,7 @@ public class ChatMessage {
 	private ChatMessage(String content, LocalDateTime createdAt, boolean isAuthor, ChatRoom chatRoom, Member member) {
 		this.content = content;
 		this.isAuthor = isAuthor;
-		this.createdAt = createdAt;
+		this.createdAt = createdAt != null ? createdAt : LocalDateTime.now();
 		this.chatRoom = chatRoom;
 		this.member = member;
 	}
@@ -65,7 +65,7 @@ public class ChatMessage {
 		return ChatMessage.builder()
 			.content(chatMessageCreateDto.content())
 			.isAuthor(chatMessageCreateDto.isAuthor())
-			.createdAt(chatMessageCreateDto.createdAt())
+			.createdAt(chatMessageCreateDto.createdAt() != null ? chatMessageCreateDto.createdAt() : LocalDateTime.now())
 			.chatRoom(chatRoom)
 			.member(member)
 			.build();


### PR DESCRIPTION
## 📋 CheckList
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. feat: 유저 조회 기능 구현)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

* close #468 

## 👩‍💻 공유 포인트 및 논의 사항
* 채팅 메시지 엔티티에서 createdAt 필드가 NULL인 경우, 현재 시간을 설정하도록 수정했습니다.
