### PR TITLE
refactor: REDIS에 채팅 메시지가 중복 저장되는 이슈

### DIFF
--- a/src/main/java/com/dart/api/application/chat/ChatMessageService.java
+++ b/src/main/java/com/dart/api/application/chat/ChatMessageService.java
@@ -40,6 +40,7 @@ public class ChatMessageService {
 
 		final ChatMessageSendDto chatMessageSendDto = chatMessage.toChatMessageSendDto(CHAT_MESSAGE_EXPIRY_SECONDS);
 		chatRedisRepository.saveChatMessage(chatMessageSendDto, member);
+		chatRedisRepository.saveBatchChatMessage(chatMessageSendDto, member);
 	}
 
 	@Scheduled(cron = CHAT_BATCH_SAVE_INTERVAL)
@@ -66,7 +67,7 @@ public class ChatMessageService {
 				.toList();
 
 			chatMessageRepository.saveAll(chatMessageList);
-			chatRedisRepository.deleteChatMessages(chatRoomId);
+			chatRedisRepository.deleteBatchChatMessages(chatRoomId);
 		}
 	}
 

--- a/src/main/java/com/dart/api/domain/chat/repository/ChatRedisRepository.java
+++ b/src/main/java/com/dart/api/domain/chat/repository/ChatRedisRepository.java
@@ -34,6 +34,14 @@ public class ChatRedisRepository {
 		listRedisRepository.addElementWithExpiry(key, messageValue, chatMessageSendDto.expirySeconds());
 	}
 
+	public void saveBatchChatMessage(ChatMessageSendDto chatMessageSendDto, Member member) {
+		final String key = REDIS_BATCH_CHAT_MESSAGE_PREFIX + chatMessageSendDto.chatRoomId().toString();
+		final ChatMessageReadDto chatMessageReadDto = createChatMessageReadDto(chatMessageSendDto, member);
+		final String messageValue = convertToJson(chatMessageReadDto);
+
+		listRedisRepository.addElement(key, messageValue);
+	}
+
 	public PageResponse<ChatMessageReadDto> getChatMessageReadDto(Long chatRoomId, int page, int size) {
 		final long end = -1 - ((long)page * size);
 		final long start = end - size + 1;
@@ -52,8 +60,8 @@ public class ChatRedisRepository {
 	}
 
 	public List<ChatMessageCreateDto> getAllBatchMessages(Long chatRoomId) {
-		return listRedisRepository.getRange(REDIS_CHAT_MESSAGE_PREFIX + chatRoomId.toString(), REDIS_BATCH_START_INDEX,
-				REDIS_BATCH_END_INDEX - 1).stream()
+		return listRedisRepository.getRange(REDIS_BATCH_CHAT_MESSAGE_PREFIX + chatRoomId.toString(),
+				REDIS_BATCH_START_INDEX, REDIS_BATCH_END_INDEX - 1).stream()
 			.map(this::parseChatMessageCreatedDto)
 			.toList();
 	}
@@ -64,6 +72,10 @@ public class ChatRedisRepository {
 
 	public void deleteChatMessages(Long chatRoomId) {
 		listRedisRepository.deleteAllElements(REDIS_CHAT_MESSAGE_PREFIX + chatRoomId.toString());
+	}
+
+	public void deleteBatchChatMessages(Long chatRoomId) {
+		listRedisRepository.deleteAllElements(REDIS_BATCH_CHAT_MESSAGE_PREFIX + chatRoomId.toString());
 	}
 
 	private ChatMessageReadDto createChatMessageReadDto(ChatMessageSendDto chatMessageSendDto, Member member) {

--- a/src/main/java/com/dart/global/common/util/ChatConstant.java
+++ b/src/main/java/com/dart/global/common/util/ChatConstant.java
@@ -12,7 +12,7 @@ public class ChatConstant {
 	public static final String ALLOWED_ORIGIN_PATTERN = "*";
 	public static final String CHAT_SESSION_USER = "authUser";
 	public static final String TOPIC_PREFIX = "/sub/ws/";
-	public static final long CHAT_MESSAGE_EXPIRY_SECONDS = 60 * 60;
+	public static final long CHAT_MESSAGE_EXPIRY_SECONDS = 48 * 60 * 60;
 	public static final String CHAT_BATCH_SAVE_INTERVAL = "0 */5 * * * ?";
 
 	public static final int MESSAGE_SIZE_LIMIT = 160 * 64 * 1024;

--- a/src/main/java/com/dart/global/common/util/RedisConstant.java
+++ b/src/main/java/com/dart/global/common/util/RedisConstant.java
@@ -15,6 +15,7 @@ public class RedisConstant {
 	public static final String REDIS_EMAIL_PREFIX = "email:";
 	public static final String REDIS_PAYMENT_PREFIX = "payment:";
 	public static final String REDIS_CHAT_MESSAGE_PREFIX = "chatMessage:";
+	public static final String REDIS_BATCH_CHAT_MESSAGE_PREFIX = "batch_chatMessage:";
 	public static final String REDIS_NICKNAME_PREFIX = "nickname:";
 	public static final String REDIS_COUPON_PREFIX = "priority_coupon:";
 	public static final String REDIS_COUPON_COUNT_PREFIX = "priority_coupon_count:";

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -3,6 +3,9 @@ spring:
     activate:
       on-profile: dev
 
+  jackson:
+    time-zone: Asia/Seoul
+
   servlet:
     multipart:
       max-file-size: 10MB

--- a/src/test/java/com/dart/api/application/chat/ChatMessageServiceTest.java
+++ b/src/test/java/com/dart/api/application/chat/ChatMessageServiceTest.java
@@ -61,6 +61,7 @@ class ChatMessageServiceTest {
 
 		// THEN
 		verify(chatRedisRepository, times(1)).saveChatMessage(any(ChatMessageSendDto.class), any(Member.class));
+		verify(chatRedisRepository, times(1)).saveBatchChatMessage(any(ChatMessageSendDto.class), any(Member.class));
 	}
 
 	@Test
@@ -128,8 +129,8 @@ class ChatMessageServiceTest {
 
 		// THEN
 		verify(chatMessageRepository, times(2)).saveAll(anyList());
-		verify(chatRedisRepository, times(1)).deleteChatMessages(chatRoomId1);
-		verify(chatRedisRepository, times(1)).deleteChatMessages(chatRoomId2);
+		verify(chatRedisRepository, times(1)).deleteBatchChatMessages(chatRoomId1);
+		verify(chatRedisRepository, times(1)).deleteBatchChatMessages(chatRoomId2);
 	}
 
 	@Test
@@ -158,8 +159,8 @@ class ChatMessageServiceTest {
 
 		// THEN
 		verify(chatMessageRepository, times(1)).saveAll(anyList());
-		verify(chatRedisRepository, times(1)).deleteChatMessages(chatRoomId1);
-		verify(chatRedisRepository, never()).deleteChatMessages(chatRoomId2);
+		verify(chatRedisRepository, times(1)).deleteBatchChatMessages(chatRoomId1);
+		verify(chatRedisRepository, never()).deleteBatchChatMessages(chatRoomId2);
 	}
 
 	@Test
@@ -182,6 +183,6 @@ class ChatMessageServiceTest {
 
 		// THEN
 		verify(chatMessageRepository, never()).saveAll(anyList());
-		verify(chatRedisRepository, never()).deleteChatMessages(anyLong());
+		verify(chatRedisRepository, never()).deleteBatchChatMessages(anyLong());
 	}
 }


### PR DESCRIPTION
## 📋 CheckList
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. feat: 유저 조회 기능 구현)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

* close #471 

## 👩‍💻 공유 포인트 및 논의 사항
* 채팅 메시지를 전송한 이후, REDIS에서 만료되어야 할 채팅 데이터가 중복해서 저장되는 이슈를 해결했습니다.
* 채팅 메시지가 REDIS에 저장되는 시간을 48시간으로 늘렸습니다.
* 관련된 테스트 코드들 모두 수정했습니다.
